### PR TITLE
Allow Hyper to run using local config if it exists (make Hyper portable)

### DIFF
--- a/app/config/paths.js
+++ b/app/config/paths.js
@@ -1,15 +1,25 @@
 // This module exports paths, names, and other metadata that is referenced
 const {homedir} = require('os');
-const {statSync} = require('fs');
-const {resolve, join} = require('path');
+const {statSync, existsSync} = require('fs');
+const {resolve, join, dirname} = require('path');
 const isDev = require('electron-is-dev');
+const {app} = require('electron');
 
 const cfgFile = '.hyper.js';
 const defaultCfgFile = 'config-default.js';
 const homeDir = homedir();
+const appDir = resolve(dirname(app.getPath('exe')), '..');
+
+let cfgLocalPath = join(appDir, cfgFile);
 
 let cfgPath = join(homeDir, cfgFile);
 let cfgDir = homeDir;
+
+// make portable if can
+if (existsSync(cfgLocalPath)) {
+  cfgPath = cfgLocalPath;
+  cfgDir = appDir;
+}
 
 const devDir = resolve(__dirname, '../..');
 const devCfg = join(devDir, cfgFile);


### PR DESCRIPTION
Some people (like me) prefer to working on portable applications. Sometimes it is just a needed. I did the same as they did with Atom.

The application checks whether a configuration file exists next to the application's executable file. In contrast to the development version - the executable file is the file combined with the update - not electron directly.

If you need to make Hyper portable, just paste your configuration file in the application folder.

The only change I've made is to check if a file with a local configuration exists. And if it exists, it will replace directory and path of config. Thanks to this, the plugins will also appear in the folder next to the executable file.