### PR TITLE
Add middle click option for quick edit

### DIFF
--- a/app/config/config-default.js
+++ b/app/config/config-default.js
@@ -116,14 +116,15 @@ module.exports = {
     bell: 'SOUND',
 
     // if `true` (without backticks and without quotes), selected text will automatically be copied to the clipboard
-    copyOnSelect: false,
+    copyOnSelect: true,
 
     // if `true` (without backticks and without quotes), hyper will be set as the default protocol client for SSH
     defaultSSHApp: true,
 
-    // if `true` (without backticks and without quotes), on right click selected text will be copied or pasted if no
+    // if `true` (without backticks and without quotes), on 'quickEditButton' click, selected text will be copied and pasted if no
     // selection is present (`true` by default on Windows and disables the context menu feature)
     // quickEdit: true,
+    // quickEditButton: 'right'
 
     // URL to custom bell
     // bellSoundURL: 'http://example.com/bell.mp3',

--- a/lib/actions/ui.js
+++ b/lib/actions/ui.js
@@ -37,7 +37,7 @@ export function openContextMenu(uid, selection) {
       uid,
       effect() {
         const state = getState();
-        const show = !state.ui.quickEdit;
+        const show = !(state.ui.quickEdit && state.ui.quickEditButton == 'right');
         if (show) {
           rpc.emit('open context menu', selection);
         }

--- a/lib/components/term-group.js
+++ b/lib/components/term-group.js
@@ -92,6 +92,7 @@ class TermGroup_ extends React.PureComponent {
       borderColor: this.props.borderColor,
       selectionColor: this.props.selectionColor,
       quickEdit: this.props.quickEdit,
+      quickEditButton: this.props.quickEditButton,
       uid
     });
 

--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -188,13 +188,15 @@ export default class Term extends React.PureComponent {
   }
 
   onMouseUp(e) {
-    if (this.props.quickEdit && e.button === 2) {
+    if (
+      this.props.quickEdit &&
+      ((this.props.quickEditButton == 'right' && e.button === 2) ||
+        (this.props.quickEditButton == 'middle' && e.button === 1))
+    ) {
       if (this.term.hasSelection()) {
         clipboard.writeText(this.term.getSelection());
-        this.term.clearSelection();
-      } else {
-        document.execCommand('paste');
       }
+      document.execCommand('paste');
     } else if (this.props.copyOnSelect && this.term.hasSelection()) {
       clipboard.writeText(this.term.getSelection());
     }

--- a/lib/components/terms.js
+++ b/lib/components/terms.js
@@ -116,6 +116,7 @@ export default class Terms extends React.Component {
             onURLAbort: this.props.onURLAbort,
             onContextMenu: this.props.onContextMenu,
             quickEdit: this.props.quickEdit,
+            quickEditButton: this.props.quickEditButton,
             parentProps: this.props
           });
 

--- a/lib/containers/terms.js
+++ b/lib/containers/terms.js
@@ -45,7 +45,8 @@ const TermsContainer = connect(
       bellSoundURL: state.ui.bellSoundURL,
       copyOnSelect: state.ui.copyOnSelect,
       modifierKeys: state.ui.modifierKeys,
-      quickEdit: state.ui.quickEdit
+      quickEdit: state.ui.quickEdit,
+      quickEditButton: state.ui.quickEditButton
     };
   },
   dispatch => {

--- a/lib/reducers/ui.js
+++ b/lib/reducers/ui.js
@@ -96,7 +96,8 @@ const initial = Immutable({
   },
   showHamburgerMenu: '',
   showWindowControls: '',
-  quickEdit: false
+  quickEdit: false,
+  quickEditButton: 'right'
 });
 
 const currentWindow = remote.getCurrentWindow();
@@ -235,6 +236,12 @@ const reducer = (state = initial, action) => {
               ret.quickEdit = true;
             } else if (typeof config.quickEdit !== 'undefined' && config.quickEdit !== null) {
               ret.quickEdit = config.quickEdit;
+            }
+
+            if (config.quickEditButton === undefined || config.quickEditButton === null) {
+              ret.quickEditButton = 'right';
+            } else if (typeof config.quickEditButton !== 'undefined' && config.quickEditButton !== null) {
+              ret.quickEditButton = config.quickEditButton;
             }
 
             ret._lastUpdate = now;


### PR DESCRIPTION
Adding support for middle click "quick edit" to emulate the same behaviour as linux.

This adds a config for specifying the button to be used for quick edit (either middle or right).
It also modifies the behaviour so selected text is immediately pasted (if selected).

This will probably need a few modifications so the bahaviour isn't modified for existing users.