### PR TITLE
Added item checking to "getProperties" function

### DIFF
--- a/cli/api.js
+++ b/cli/api.js
@@ -44,7 +44,17 @@ const getFileContents = memoize(() => {
 
 const getParsedFile = memoize(() => recast.parse(getFileContents()));
 
-const getProperties = memoize(() => getParsedFile().program.body[0].expression.right.properties);
+// From all items in the property file, find the first `module.exports` expression
+// Assumes that the `.hyper.js` file will never declare `module.exports` more than once
+const getProperties = memoize(
+  () =>
+    getParsedFile().program.body.find(
+      bodyItem =>
+        bodyItem.type === 'ExpressionStatement' &&
+        bodyItem.expression.left.object.name === 'module' &&
+        bodyItem.expression.left.property.name === 'exports'
+    ).expression.right.properties
+);
 
 const getPlugins = memoize(() => getProperties().find(property => property.key.name === 'plugins').value.elements);
 


### PR DESCRIPTION
<details>
<summary>General Changes:</summary>


* Altered function `getProperties` from `api.js`.
* Removed hardcoded assumption that first item of `.hyper.js` is the `module.exports` expression.
* Replaced with a basic check for the first valid expression.
* Fixes issue where not having `model.exports` as the first statement in `.hyper.js` would cause installing plugins from Hyper's command-line to unexpectedly fail.


</details>

 I tested things on my end, changes fixed a bug I ran into as detailed above. However, I only started using Hyper for the first time today so I wouldn't be surprised if there was a use case I didn't consider when testing. This should likely be looked over by someone with better knowledge of the codebase. It was a real small change; hopefully wont take up too much time. 

Let me know if there's anything else I can do. Hope my work proves useful to the project!
<!-- Hi there! Thanks for submitting a PR! We're excited to see what you've got for us.

- To help whoever reviews your PR, it'd be extremely helpful for you to list whether your PR is ready to be merged,
If there's anything left to do and if there are any related PRs
- It'd also be extremely helpful to enable us to update your PR incase we need to rebase or what-not by checking `Allow edits from maintainers`
- If your PR changes some API, please make a PR for hyper website too: https://github.com/zeit/hyper-site.

Thanks, again! -->
