### PR TITLE
Add shortcut for opening hamburger menu (Linux)

### DIFF
--- a/app/commands.js
+++ b/app/commands.js
@@ -111,7 +111,7 @@ const commands = {
     installCLI(true);
   },
   'window:hamburgerMenu': () => {
-    if (getConfig().showHamburgerMenu) {
+    if (getConfig().showHamburgerMenu || getConfig().showHamburgerMenu === '') {
       Menu.getApplicationMenu().popup({x: 15, y: 15});
     }
   }

--- a/app/keymaps/linux.json
+++ b/app/keymaps/linux.json
@@ -3,6 +3,7 @@
   "window:reload": "ctrl+shift+r",
   "window:reloadFull": "ctrl+shift+f5",
   "window:preferences": "ctrl+,",
+  "window:hamburgerMenu": "alt",
   "zoom:reset": "ctrl+0",
   "zoom:in": "ctrl+=",
   "zoom:out": "ctrl+-",


### PR DESCRIPTION
I also had to edit the command `window:hamburgerMenu`  to account for default config (`showHamburgerMenu===''`)

It seems that there are some useful methods inside lib that would facilitate this command, but these are in Typescript so I couldn't use them (https://github.com/zeit/hyper/blob/canary/lib/components/header.js#L42, https://github.com/zeit/hyper/blob/canary/lib/containers/header.js#L41), I'm not sure if these are meant to be used here in the first place.

It's my first contribution, so I'm not very familiar with the project yet, let me know if there's anything else that I should consider.

Issue #3443

<!-- Hi there! Thanks for submitting a PR! We're excited to see what you've got for us.

- To help whoever reviews your PR, it'd be extremely helpful for you to list whether your PR is ready to be merged,
If there's anything left to do and if there are any related PRs
- It'd also be extremely helpful to enable us to update your PR incase we need to rebase or what-not by checking `Allow edits from maintainers`
- If your PR changes some API, please make a PR for hyper website too: https://github.com/zeit/hyper-site.

Thanks, again! -->
