### PR TITLE
Enable code signing in github actions

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -27,6 +27,11 @@ jobs:
         run: |
           cp build/canary.ico build/icon.ico
           cp build/canary.icns build/icon.icns
+      # - name: Get Certificate for signing
+      #   if: github.event_name == 'push'
+      #   run: |
+      #     echo "::set-env name=CSC_LINK::${{ secrets.MAC_CERT_P12_BASE64 }}"
+      #     echo "::set-env name=CSC_KEY_PASSWORD::${{ secrets.MAC_CERT_P12_PASSWORD }}"
       - name: Build
         run: yarn run dist --publish=never
       - name: Get macOS Artifact Names
@@ -61,7 +66,7 @@ jobs:
           cp build/canary.ico build/icon.ico
           cp build/canary.icns build/icon.icns
       - name: Build
-        run: yarn run dist --publish=never 
+        run: yarn run dist --publish=never
       - name: Get Linux Artifact Names
         id: getlinuxfilename
         run: |
@@ -114,6 +119,11 @@ jobs:
         run: |
           Copy-Item .\build\canary.ico .\build\icon.ico
           Copy-Item .\build\canary.icns .\build\icon.icns
+      - name: Get Certificate for signing
+        if: github.event_name == 'push'
+        run: |
+          Write-Host "::set-env name=CSC_LINK::${{ secrets.WIN_CERT_P12_BASE64 }}"
+          Write-Host "::set-env name=CSC_KEY_PASSWORD::${{ secrets.WIN_CERT_P12_PASSWORD }}"
       - name: Build
         run: yarn run dist --publish=never
       - name: Get Windows Artifact Names


### PR DESCRIPTION
electron-builder needs two env vars `CSC_LINK`(url or base64 version of the p12 or pfx file) and `CSC_KEY_PASSWORD`
These can be set from github secrets before the build step

@timothyis this can be merged after setting the following secrets in the repo
For mac: `MAC_CERT_P12_BASE64` and `MAC_CERT_P12_PASSWORD`
For windows: `WIN_CERT_P12_BASE64` and `WIN_CERT_P12_PASSWORD`