### PR TITLE
disable ligatures in default config

### DIFF
--- a/app/config/config-default.js
+++ b/app/config/config-default.js
@@ -158,8 +158,8 @@ module.exports = {
     // todo: does not pick up config changes automatically, need to restart terminal :/
     webLinksActivationKey: '',
 
-    // if `true` (without backticks and without quotes), Hyper will ignore ligatures provided by some fonts
-    disableLigatures: false,
+    // if `false` (without backticks and without quotes), Hyper will use ligatures provided by some fonts
+    disableLigatures: true,
 
     // for advanced config flags please refer to https://hyper.is/#cfg
   },


### PR DESCRIPTION
There have been few issues with font rendering due to a small bug in https://github.com/princjef/font-ligatures which is a dependency of xterm-addon-ligatures.
Ref - #4360 #3391 ..

I've opened a pr https://github.com/princjef/font-ligatures/pull/18 for it and an issue in xterm https://github.com/xtermjs/xterm.js/issues/2980

Since not everyone will face this issue, it's better to have ligatures disabled in the default config, than removing it from the code. So that if someone wants to try it out, they can enable it.
We can have ligatures enabled by default again when the issue above is closed.