### PR TITLE
fix keymap to open hamburger menu

### DIFF
--- a/app/commands.ts
+++ b/app/commands.ts
@@ -111,8 +111,8 @@ const commands: Record<string, (focusedWindow?: BrowserWindow) => void> = {
     installCLI(true);
   },
   'window:hamburgerMenu': () => {
-    if (getConfig().showHamburgerMenu) {
-      Menu.getApplicationMenu()!.popup({x: 15, y: 15});
+    if (process.platform !== 'darwin' && ['', true].includes(getConfig().showHamburgerMenu)) {
+      Menu.getApplicationMenu()!.popup({x: 25, y: 22});
     }
   }
 };


### PR DESCRIPTION
Fix #3443 
fixed the if condition, earlier it needed `showHamburgerMenu` to be true and would show it on mac also if keymap was defined.
Changed the coordinates based on their value when menu opened by clicking the button.