### PR TITLE
fix system context menu entry on windows

### DIFF
--- a/app/index.ts
+++ b/app/index.ts
@@ -29,18 +29,13 @@ if (process.platform === 'win32') {
   switch (process.argv[1]) {
     case '--squirrel-install':
     case '--squirrel-updated':
-      systemContextMenu.add(() => {
-        checkSquirrel();
-      });
+      systemContextMenu.add();
       break;
     case '--squirrel-uninstall':
-      systemContextMenu.remove(() => {
-        checkSquirrel();
-      });
+      systemContextMenu.remove();
       break;
-    default:
-      checkSquirrel();
   }
+  checkSquirrel();
 }
 
 // Native

--- a/app/system-context-menu.ts
+++ b/app/system-context-menu.ts
@@ -9,14 +9,18 @@ if (process.platform === 'win32') {
 }
 
 const appPath = `"${process.execPath}"`;
-const regKey = `Software\\Classes\\Directory\\background\\shell\\Hyper`;
+const regKeys = [
+  `Software\\Classes\\Directory\\Background\\shell\\Hyper`,
+  `Software\\Classes\\Directory\\shell\\Hyper`,
+  `Software\\Classes\\Drive\\shell\\Hyper`
+];
 const regParts = [
   {key: 'command', name: '', value: `${appPath} "%V"`},
   {name: '', value: 'Open Hyper here'},
   {name: 'Icon', value: `${appPath}`}
 ];
 
-function addValues(hyperKey: regTypes.HKEY, commandKey: regTypes.HKEY, callback: Function) {
+function addValues(hyperKey: regTypes.HKEY, commandKey: regTypes.HKEY) {
   try {
     Registry.setValueSZ(hyperKey, regParts[1].name, regParts[1].value);
   } catch (error) {
@@ -32,30 +36,32 @@ function addValues(hyperKey: regTypes.HKEY, commandKey: regTypes.HKEY, callback:
   } catch (err_) {
     console.error(err_);
   }
-  callback();
 }
 
-export const add = (callback: Function) => {
-  try {
-    const hyperKey =
-      Registry.openKey(Registry.HKCU, regKey, Registry.Access.ALL_ACCESS) ||
-      Registry.createKey(Registry.HKCU, regKey, Registry.Access.ALL_ACCESS);
-    const commandKey =
-      Registry.openKey(Registry.HKCU, `${regKey}\\${regParts[0].key}`, Registry.Access.ALL_ACCESS) ||
-      Registry.createKey(Registry.HKCU, `${regKey}\\${regParts[0].key}`, Registry.Access.ALL_ACCESS);
-    addValues(hyperKey, commandKey, callback);
-    Registry.closeKey(hyperKey);
-    Registry.closeKey(commandKey);
-  } catch (error) {
-    console.error(error);
-  }
+export const add = () => {
+  regKeys.forEach((regKey) => {
+    try {
+      const hyperKey =
+        Registry.openKey(Registry.HKCU, regKey, Registry.Access.ALL_ACCESS) ||
+        Registry.createKey(Registry.HKCU, regKey, Registry.Access.ALL_ACCESS);
+      const commandKey =
+        Registry.openKey(Registry.HKCU, `${regKey}\\${regParts[0].key}`, Registry.Access.ALL_ACCESS) ||
+        Registry.createKey(Registry.HKCU, `${regKey}\\${regParts[0].key}`, Registry.Access.ALL_ACCESS);
+      addValues(hyperKey, commandKey);
+      Registry.closeKey(hyperKey);
+      Registry.closeKey(commandKey);
+    } catch (error) {
+      console.error(error);
+    }
+  });
 };
 
-export const remove = (callback: Function) => {
-  try {
-    Registry.deleteTree(Registry.HKCU, regKey);
-  } catch (err) {
-    console.error(err);
-  }
-  callback();
+export const remove = () => {
+  regKeys.forEach((regKey) => {
+    try {
+      Registry.deleteTree(Registry.HKCU, regKey);
+    } catch (err) {
+      console.error(err);
+    }
+  });
 };

--- a/app/ui/window.ts
+++ b/app/ui/window.ts
@@ -1,5 +1,5 @@
 import {app, BrowserWindow, shell, Menu, BrowserWindowConstructorOptions} from 'electron';
-import {isAbsolute} from 'path';
+import {isAbsolute, normalize, sep} from 'path';
 import {parse as parseUrl} from 'url';
 import {v4 as uuidv4} from 'uuid';
 import fileUriToPath from 'file-uri-to-path';
@@ -60,9 +60,16 @@ export function newWindow(
   };
 
   // set working directory
+  let argPath = process.argv[1];
+  if (argPath && process.platform === 'win32') {
+    if (/[a-zA-Z]:"/.test(argPath)) {
+      argPath = argPath.replace('"', sep);
+    }
+    argPath = normalize(argPath + sep);
+  }
   let workingDirectory = homeDirectory;
-  if (process.argv[1] && isAbsolute(process.argv[1])) {
-    workingDirectory = process.argv[1];
+  if (argPath && isAbsolute(argPath)) {
+    workingDirectory = argPath;
   } else if (cfg.workingDirectory && isAbsolute(cfg.workingDirectory)) {
     workingDirectory = cfg.workingDirectory;
   }


### PR DESCRIPTION
Fix #3564
Fix #3062
the path passed as argument when opened in drive root is of the form `C:"`, added some logic to convert it to `C:\`
Added 2 more registry keys which enable right clicking on folders and drives, currently it was just on folder background.
Also removed callback in the context menu code as `native-reg` is synchronous