### PR TITLE
add .idea folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ yarn-error.log
 
 .DS_Store
 .vscode/settings.json
+.idea


### PR DESCRIPTION
`.idea/` is a folder containing metadata for Jetbrains IDEs such as PyCharm, WebStorm, and Intellij

<!-- Hi there! Thanks for submitting a PR! We're excited to see what you've got for us.

- To help whoever reviews your PR, it'd be extremely helpful for you to list whether your PR is ready to be merged,
If there's anything left to do and if there are any related PRs
- It'd also be extremely helpful to enable us to update your PR incase we need to rebase or what-not by checking `Allow edits from maintainers`
- If your PR changes some API, please make a PR for hyper website too: https://github.com/vercel/hyper-site.

Thanks, again! -->
