### PR TITLE
Show config error notfications after app is ready

### DIFF
--- a/app/config/init.ts
+++ b/app/config/init.ts
@@ -16,7 +16,7 @@ const _syntaxValidation = (cfg: string) => {
   try {
     return new vm.Script(cfg, {filename: '.hyper.js', displayErrors: true});
   } catch (err) {
-    notify('Error loading config:', `${err.name}, see DevTools for more info`, {error: err});
+    notify(`Error loading config: ${err.name}`, `${err}`, {error: err});
   }
 };
 

--- a/app/notify.ts
+++ b/app/notify.ts
@@ -1,4 +1,4 @@
-import {Notification} from 'electron';
+import {app, Notification} from 'electron';
 import {icon} from './config/paths';
 
 export default function notify(title: string, body = '', details: {error?: any} = {}) {
@@ -6,5 +6,15 @@ export default function notify(title: string, body = '', details: {error?: any} 
   if (details.error) {
     console.error(details.error);
   }
-  new Notification({title, body, ...(process.platform === 'linux' && {icon})}).show();
+  if (app.isReady()) {
+    _createNotification(title, body);
+  } else {
+    app.on('ready', () => {
+      _createNotification(title, body);
+    });
+  }
 }
+
+const _createNotification = (title: string, body: string) => {
+  new Notification({title, body, ...(process.platform === 'linux' && {icon})}).show();
+};


### PR DESCRIPTION

Fixes #1589 by waiting until the app is ready to show Notifications. When the config file has a syntax error, the app is not ready so a Notification can't be created yet. In this change, notify() checks to see if the app isReady() and, if it's not, creates the Notification after the 'ready' event is issued.

Now if the config file has a syntax error, the default configuration will be used and two notifications will be sent: line 19 of init.ts issues a notification with the syntax error, and line 36 of init.ts notifies that it couldn't find the 'config' key.