### PR TITLE
set npm registry in yarn config

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+registry "https://registry.npmjs.org/"

--- a/app/.yarnrc
+++ b/app/.yarnrc
@@ -1,0 +1,1 @@
+registry "https://registry.npmjs.org/"


### PR DESCRIPTION
added registry to yarnrc, so that it's used for hyper, without needing to change yarn global config