### PR TITLE
Add support for SIGQUIT, SIGSTOP, and tmux special character bindings

### DIFF
--- a/app/commands.ts
+++ b/app/commands.ts
@@ -101,6 +101,15 @@ const commands: Record<string, (focusedWindow?: BrowserWindow) => void> = {
   'editor:break': (focusedWindow) => {
     focusedWindow?.rpc.emit('session break req');
   },
+  'editor:stop': (focusedWindow) => {
+    focusedWindow?.rpc.emit('session stop req');
+  },
+  'editor:quit': (focusedWindow) => {
+    focusedWindow?.rpc.emit('session quit req');
+  },
+  'editor:tmux': (focusedWindow) => {
+    focusedWindow?.rpc.emit('session tmux req');
+  },
   'editor:search': (focusedWindow) => {
     focusedWindow?.rpc.emit('session search');
   },

--- a/lib/index.tsx
+++ b/lib/index.tsx
@@ -135,6 +135,18 @@ rpc.on('session break req', () => {
   store_.dispatch(sessionActions.sendSessionData(null, '\x03'));
 });
 
+rpc.on('session stop req', () => {
+  store_.dispatch(sessionActions.sendSessionData(null, '\x1a'));
+});
+
+rpc.on('session quit req', () => {
+  store_.dispatch(sessionActions.sendSessionData(null, '\x1c'));
+});
+
+rpc.on('session tmux req', () => {
+  store_.dispatch(sessionActions.sendSessionData(null, '\x02'));
+});
+
 rpc.on('session search', () => {
   store_.dispatch(sessionActions.onSearch());
 });


### PR DESCRIPTION
The key-bindings should be up the user/I think that's thorny, but this at least exposes some general terminal command codes to the key-mapping settings.
