### PR TITLE
Fix installation instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Use [Homebrew Cask](https://brew.sh) to download the app by running these comman
 
 ```bash
 brew update
-brew cask install hyper
+brew install --cask hyper
 ```
 
 ### Windows


### PR DESCRIPTION
Fix error when installing using latest Homebrew in macOS. Just fix README.md.

![Calling brew cask install is disabled](https://user-images.githubusercontent.com/8146876/103055585-fc6ca680-45dd-11eb-85d9-2f4edee88f78.png)
