### PR TITLE
copy yarn.lock to /target

### DIFF
--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -42,6 +42,10 @@ const config: webpack.Configuration[] = [
             to: '[name].[ext]'
           },
           {
+            from: './app/yarn.lock',
+            to: 'yarn.lock'
+          },
+          {
             from: './app/keymaps/*.json',
             globOptions: {ignore: ['**/node_modules/**']},
             to: './keymaps/[name].[ext]'


### PR DESCRIPTION
We copy `node_modules` from `target` to `app`
Need to copy `yarn.lock` to ensure the correct versions are getting installed (faced some errors with fsevents because of this)