### PR TITLE
Change windows build target to nsis

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -152,17 +152,10 @@ jobs:
       - name: Get Windows Artifact Names
         id: getwindowsfilename
         run: |
-          Write-Host "::set-output name=exeName::$(Get-ChildItem -Name .\dist\squirrel-windows\ | Select-String exe)"
-          Write-Host "::set-output name=exePath::dist/squirrel-windows/$(Get-ChildItem -Name .\dist\squirrel-windows\ | Select-String exe)"
-          Write-Host "::set-output name=nupkgName::$(Get-ChildItem -Name .\dist\squirrel-windows\ | Select-String nupkg)"
-          Write-Host "::set-output name=nupkgPath::dist/squirrel-windows/$(Get-ChildItem -Name .\dist\squirrel-windows\ | Select-String nupkg)"
+          Write-Host "::set-output name=exeName::$(Get-ChildItem -Name .\dist\ | Select-String exe$)"
+          Write-Host "::set-output name=exePath::dist/$(Get-ChildItem -Name .\dist\ | Select-String exe$)"
       - name: Archive Windows Build Artifacts (exe)
         uses: actions/upload-artifact@v2
         with:
           name: ${{ steps.getwindowsfilename.outputs.exeName }}
           path: ${{ steps.getwindowsfilename.outputs.exePath }}
-      - name: Archive Windows Build Artifacts (nupkg)
-        uses: actions/upload-artifact@v2
-        with:
-          name: ${{ steps.getwindowsfilename.outputs.nupkgName }}
-          path: ${{ steps.getwindowsfilename.outputs.nupkgPath }}

--- a/app/index.ts
+++ b/app/index.ts
@@ -9,35 +9,6 @@ if (['--help', '-v', '--version'].includes(process.argv[1])) {
   process.exit();
 }
 
-const checkSquirrel = () => {
-  let squirrel;
-
-  try {
-    squirrel = require('electron-squirrel-startup');
-    //eslint-disable-next-line no-empty
-  } catch (err) {}
-  if (squirrel) {
-    process.exit();
-  }
-};
-
-// handle startup squirrel events
-if (process.platform === 'win32') {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const systemContextMenu = require('./system-context-menu');
-
-  switch (process.argv[1]) {
-    case '--squirrel-install':
-    case '--squirrel-updated':
-      systemContextMenu.add();
-      break;
-    case '--squirrel-uninstall':
-      systemContextMenu.remove();
-      break;
-  }
-  checkSquirrel();
-}
-
 // Native
 import {resolve} from 'path';
 

--- a/app/package.json
+++ b/app/package.json
@@ -17,7 +17,6 @@
     "default-shell": "1.0.1",
     "electron-fetch": "1.7.3",
     "electron-is-dev": "1.2.0",
-    "electron-squirrel-startup": "1.0.0",
     "electron-store": "6.0.1",
     "file-uri-to-path": "2.0.0",
     "fs-extra": "9.0.1",

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -163,13 +163,6 @@ debounce-fn@^4.0.0:
   dependencies:
     mimic-fn "^3.0.0"
 
-debug@^2.2.0:
-  version "2.6.9"
-  resolved "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
-  integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
-  dependencies:
-    ms "2.0.0"
-
 default-shell@1.0.1, default-shell@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/default-shell/-/default-shell-1.0.1.tgz#752304bddc6174f49eb29cb988feea0b8813c8bc"
@@ -193,13 +186,6 @@ electron-is-dev@1.2.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/electron-is-dev/-/electron-is-dev-1.2.0.tgz#2e5cea0a1b3ccf1c86f577cee77363ef55deb05e"
   integrity sha512-R1oD5gMBPS7PVU8gJwH6CtT0e6VSoD0+SzSnYpNm+dBkcijgA+K7VAMHDfnRq/lkKPZArpzplTW6jfiMYosdzw==
-
-electron-squirrel-startup@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/electron-squirrel-startup/-/electron-squirrel-startup-1.0.0.tgz#19b4e55933fa0ef8f556784b9c660f772546a0b8"
-  integrity sha1-GbTlWTP6Dvj1VnhLnGYPdyVGoLg=
-  dependencies:
-    debug "^2.2.0"
 
 electron-store@6.0.1:
   version "6.0.1"
@@ -520,11 +506,6 @@ mkdirp@1.0.4:
   version "1.0.4"
   resolved "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
-
-ms@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
-  integrity sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
 
 ms@2.1.3:
   version "2.1.3"

--- a/build/win/installer.nsh
+++ b/build/win/installer.nsh
@@ -1,0 +1,19 @@
+!macro customInstall
+  WriteRegStr HKCU "Software\Classes\Directory\Background\shell\Hyper" "" "Open Hyper here"
+  WriteRegStr HKCU "Software\Classes\Directory\Background\shell\Hyper" "Icon" "$appExe"
+  WriteRegStr HKCU "Software\Classes\Directory\Background\shell\Hyper\command" "" `$appExe "%V"`
+
+  WriteRegStr HKCU "Software\Classes\Directory\shell\Hyper" "" "Open Hyper here"
+  WriteRegStr HKCU "Software\Classes\Directory\shell\Hyper" "Icon" "$appExe"
+  WriteRegStr HKCU "Software\Classes\Directory\shell\Hyper\command" "" `$appExe "%V"`
+
+  WriteRegStr HKCU "Software\Classes\Drive\shell\Hyper" "" "Open Hyper here"
+  WriteRegStr HKCU "Software\Classes\Drive\shell\Hyper" "Icon" "$appExe"
+  WriteRegStr HKCU "Software\Classes\Drive\shell\Hyper\command" "" `$appExe "%V"`
+!macroend
+
+!macro customUnInstall
+  DeleteRegKey HKCU "Software\Classes\Directory\Background\shell\Hyper"
+  DeleteRegKey HKCU "Software\Classes\Directory\shell\Hyper"
+  DeleteRegKey HKCU "Software\Classes\Drive\shell\Hyper"
+!macroend

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -50,6 +50,9 @@
     ],
     "rfc3161TimeStampServer": "http://timestamp.comodoca.com"
   },
+  "nsis": {
+    "include": "build/win/installer.nsh"
+  },
   "mac": {
     "target": {
       "target": "default",

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -46,7 +46,7 @@
   },
   "win": {
     "target": [
-      "squirrel"
+      "nsis"
     ],
     "rfc3161TimeStampServer": "http://timestamp.comodoca.com"
   },

--- a/package.json
+++ b/package.json
@@ -99,7 +99,6 @@
     "cross-env": "7.0.3",
     "electron": "^11.2.0",
     "electron-builder": "^22.10.4",
-    "electron-builder-squirrel-windows": "^22.10.4",
     "electron-devtools-installer": "3.1.1",
     "electron-rebuild": "2.3.4",
     "eslint": "7.18.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1348,19 +1348,6 @@ archiver@^5.0.0:
     tar-stream "^2.1.4"
     zip-stream "^4.0.4"
 
-archiver@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.npmjs.org/archiver/-/archiver-5.1.0.tgz#05b0f6f7836f3e6356a0532763d2bb91017a7e37"
-  integrity sha512-iKuQUP1nuKzBC2PFlGet5twENzCfyODmvkxwDV0cEFXavwcLrIW5ssTuHi9dyTPvpWr6Faweo2eQaQiLIwyXTA==
-  dependencies:
-    archiver-utils "^2.1.0"
-    async "^3.2.0"
-    buffer-crc32 "^0.2.1"
-    readable-stream "^3.6.0"
-    readdir-glob "^1.0.0"
-    tar-stream "^2.1.4"
-    zip-stream "^4.0.4"
-
 are-we-there-yet@~1.1.2:
   version "1.1.5"
   resolved "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz#4b35c2944f062a8bfcda66410760350fe9ddfc21"
@@ -2871,20 +2858,6 @@ ejs@^3.1.5:
   integrity sha512-dldq3ZfFtgVTJMLjOe+/3sROTzALlL9E34V4/sDtUd/KlBSS0s6U1/+WPE1B4sj9CXHJpL1M6rhNJnc9Wbal9w==
   dependencies:
     jake "^10.6.1"
-
-electron-builder-squirrel-windows@^22.10.4:
-  version "22.10.4"
-  resolved "https://registry.npmjs.org/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-22.10.4.tgz#fd23d7124dbed62fe2431933f05e23feaaef50b6"
-  integrity sha512-Kv6FO7OPdlhG02i+7fbOAWc7JCwtGJOzg9gbJySAE4cNhA49bQF4/GyQhFJYhJgg/AapfuV+SLOxlgrD+33UHg==
-  dependencies:
-    app-builder-lib "22.10.4"
-    archiver "^5.1.0"
-    bluebird-lst "^1.0.9"
-    builder-util "22.10.4"
-    fs-extra "^9.0.1"
-    sanitize-filename "^1.6.3"
-  optionalDependencies:
-    "7zip-bin" "~5.0.3"
 
 electron-builder@^22.10.4:
   version "22.10.4"


### PR DESCRIPTION
Build has been failing for few days because of `squirrel.windows`
I've opened an issue electron-userland/electron-builder#5551 but thought that it's about time we start using the NSIS installer.

I've added nsis script to add hyper to system context menu on install and remove on uninstall.
Also tested that it doesn't cause any unicode issues while accessing the registry.

This has made the `app/system-context-menu.ts` file unused for now.
We can delete it or use it to add an item in the plugins menu as `add hyper to system context menu` like the `install hyper command to path` menu item.

Since the nsis install path is `%LOCALAPPDATA\Programs\Hyper` instead of squirrel's `%LOCALAPPDATA\hyper\app-<version>` I've changed the cli install code to remove old paths.

Added Bonus - This has resulted in ~30% reduction in Setup file size.