### PR TITLE
Rename plugins menu to tools menu

### DIFF
--- a/app/menus/menu.ts
+++ b/app/menus/menu.ts
@@ -7,7 +7,7 @@ import {icon} from '../config/paths';
 import viewMenu from './menus/view';
 import shellMenu from './menus/shell';
 import editMenu from './menus/edit';
-import pluginsMenu from './menus/plugins';
+import toolsMenu from './menus/tools';
 import windowMenu from './menus/window';
 import helpMenu from './menus/help';
 import darwinMenu from './menus/darwin';
@@ -64,7 +64,7 @@ export const createMenu = (
     shellMenu(commandKeys, execCommand),
     editMenu(commandKeys, execCommand),
     viewMenu(commandKeys, execCommand),
-    pluginsMenu(commandKeys, execCommand),
+    toolsMenu(commandKeys, execCommand),
     windowMenu(commandKeys, execCommand),
     helpMenu(commandKeys, showAbout)
   ];

--- a/app/menus/menus/tools.ts
+++ b/app/menus/menus/tools.ts
@@ -5,10 +5,10 @@ export default (
   execCommand: (command: string, focusedWindow?: BrowserWindow) => void
 ): MenuItemConstructorOptions => {
   return {
-    label: 'Plugins',
+    label: 'Tools',
     submenu: [
       {
-        label: 'Update',
+        label: 'Update plugins',
         accelerator: commands['plugins:update'],
         click() {
           execCommand('plugins:update');


### PR DESCRIPTION
Now that plugins menu has more items (#5256), I think we should rename it to Tools menu