### PR TITLE
remove `about` role from help menu item

### DIFF
--- a/app/menus/menus/help.ts
+++ b/app/menus/menus/help.ts
@@ -94,7 +94,7 @@ ${JSON.stringify(getPlugins(), null, 2)}
     submenu.push(
       {type: 'separator'},
       {
-        role: 'about',
+        label: 'About Hyper',
         click() {
           showAbout();
         }


### PR DESCRIPTION
Looks like the `about` role in menu items have changed at some point in electron.
Right now, clicking `About Hyper` from the help menu shows this
![Screenshot 2021-02-05 at 22 01 59](https://user-images.githubusercontent.com/16598275/107061977-ca667b00-67fe-11eb-9005-9dd8bbf35e8d.png)
The `click` value is not getting used because of the `role` and electron is showing some default dialog (see [this](https://www.electronjs.org/docs/api/menu-item#new-menuitemoptions)).
This pr changes it back to
![Screenshot 2021-02-05 at 22 02 14](https://user-images.githubusercontent.com/16598275/107062247-1c0f0580-67ff-11eb-900d-e60ddf347bb5.png)
