### PR TITLE
increase timeout for spectron tests

### DIFF
--- a/ava-spectron.config.js
+++ b/ava-spectron.config.js
@@ -5,5 +5,6 @@ export default {
     compileAsTests: ['**/testUtils/**/*']
   },
   extensions: ['ts'],
-  require: ['ts-node/register/transpile-only']
+  require: ['ts-node/register/transpile-only'],
+  timeout: '30s'
 };


### PR DESCRIPTION
from default 10s to 30s, as sometimes it runs out of time while starting the app

<!-- Hi there! Thanks for submitting a PR! We're excited to see what you've got for us.

- To help whoever reviews your PR, it'd be extremely helpful for you to list whether your PR is ready to be merged,
If there's anything left to do and if there are any related PRs
- It'd also be extremely helpful to enable us to update your PR incase we need to rebase or what-not by checking `Allow edits from maintainers`
- If your PR changes some API, please make a PR for hyper website too: https://github.com/vercel/hyper-site.

Thanks, again! -->
