### PR TITLE
remove outdated git bash example from config

### DIFF
--- a/app/config/config-default.js
+++ b/app/config/config-default.js
@@ -114,10 +114,6 @@ module.exports = {
     //
     // Cygwin
     // - Example: `C:\\cygwin64\\bin\\bash.exe`
-    //
-    // Git Bash
-    // - Example: `C:\\Program Files\\Git\\git-cmd.exe`
-    // Then Add `--command=usr/bin/bash.exe` to shellArgs
     shell: '',
 
     // for setting shell arguments (i.e. for using interactive shellArgs: `['-i']`)


### PR DESCRIPTION
This example causes too much confusion as there are two examples for git bash and doesn't even work properly. The first one is better and works properly.