### PR TITLE
Fix spectron pr comment action

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -62,3 +62,14 @@ jobs:
             dist/*.deb
             dist/*.rpm
             dist/*.exe
+      - name: Save the pr number in an artifact
+        if: github.event_name == 'pull_request'
+        env:
+          PR_NUM: ${{ github.event.number }}
+        run: echo $PR_NUM > pr_num.txt
+      - name: Upload the pr num
+        uses: actions/upload-artifact@v2
+        if: github.event_name == 'pull_request'
+        with:
+          name: pr_num
+          path: ./pr_num.txt

--- a/.github/workflows/spectron_comment.yml
+++ b/.github/workflows/spectron_comment.yml
@@ -20,6 +20,18 @@ jobs:
           workflow: nodejs.yml
           run_id: ${{ github.event.workflow_run.id }}
           name: spectron
+      - name: Get PR number
+        uses: dawidd6/action-download-artifact@v2.11.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          workflow: nodejs.yml
+          run_id: ${{ github.event.workflow_run.id }}
+          name: pr_num
+      - name: Read the pr_num file
+        id: pr_num_reader
+        uses: juliangruber/read-file-action@v1.0.0
+        with:
+          path: ./pr_num.txt
       - name: List images
         run: ls -al
       - name: Upload images to imgur
@@ -39,6 +51,6 @@ jobs:
             Thank you for contributing to Hyper!
         with:
           type: create
-          issue_number: ${{ github.event.workflow_run.pull_requests[0].number }}
+          issue_number: ${{ steps.pr_num_reader.outputs.content }}
           token: ${{ secrets.GITHUB_TOKEN }}
           body: ${{ format(env.MESSAGE, env.IMG_MARKDOWN) }}


### PR DESCRIPTION
Looks like the `workflow_run` field from github context doesn't contain the pull requests infor when the pr is made from a fork.
Adding this workaround from https://github.com/devicons/devicon