### PR TITLE
add wordpad fallback to notepad

### DIFF
--- a/app/config/open.ts
+++ b/app/config/open.ts
@@ -54,7 +54,13 @@ const hasDefaultSet = () => {
 // This mimics shell.openItem, true if it worked, false if not.
 const openNotepad = (file: string) =>
   new Promise<boolean>((resolve) => {
-    exec(`start notepad.exe ${file}`, (error) => {
+    exec(`notepad.exe ${file}`, (error) => {
+      if (error) {
+        console.warn('Error opening notepad, using wordpad fallback');
+        exec(`start write.exe ${file}`, (error) => {
+          resolve(!error);
+        });
+      };
       resolve(!error);
     });
   });


### PR DESCRIPTION
<!-- Hi there! Thanks for submitting a PR! We're excited to see what you've got for us.

- To help whoever reviews your PR, it'd be extremely helpful for you to list whether your PR is ready to be merged,
If there's anything left to do and if there are any related PRs
- It'd also be extremely helpful to enable us to update your PR incase we need to rebase or what-not by checking `Allow edits from maintainers`
- If your PR changes some API, please make a PR for hyper website too: https://github.com/vercel/hyper-site.

Thanks, again! you're welcome!!11!1! -->
Uses wordpad when notepad doesn't work because notepad is an optional feature. Resolves #5504 
