### PR TITLE
use bzip2 compression for deb

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -110,6 +110,7 @@
     "darkModeSupport": true
   },
   "deb": {
+    "compression": "bzip2",
     "afterInstall": "./build/linux/after-install.tpl"
   },
   "rpm": {


### PR DESCRIPTION
the linux build fails many times due to xz (like the ci is failing currently)
xz gives good compression but bzip2 is also ok for us.