### PR TITLE
Add Windows Vibrancy

### DIFF
--- a/app/ui/window.ts
+++ b/app/ui/window.ts
@@ -1,4 +1,5 @@
-import {app, BrowserWindow, shell, Menu, BrowserWindowConstructorOptions} from 'electron';
+import {AcrylicBrowserWindowConstructorOptions, BrowserWindow, setVibrancy } from 'electron-acrylic-window';
+import {app, shell, Menu, BrowserWindowConstructorOptions} from 'electron';
 import {isAbsolute, normalize, sep} from 'path';
 import {parse as parseUrl} from 'url';
 import {v4 as uuidv4} from 'uuid';
@@ -24,7 +25,7 @@ export function newWindow(
   const classOpts = Object.assign({uid: uuidv4()});
   app.plugins.decorateWindowClass(classOpts);
 
-  const winOpts: BrowserWindowConstructorOptions = {
+  const winOpts: AcrylicBrowserWindowConstructorOptions = {
     minWidth: 370,
     minHeight: 190,
     backgroundColor: toElectronBackgroundColor(cfg.backgroundColor || '#000'),
@@ -42,6 +43,7 @@ export function newWindow(
       enableRemoteModule: true,
       contextIsolation: false
     },
+    vibrancy: cfg.vibrancy,
     ...options_
   };
   const window = new BrowserWindow(app.plugins.getDecoratedBrowserOptions(winOpts));

--- a/lib/components/term.tsx
+++ b/lib/components/term.tsx
@@ -37,7 +37,7 @@ const isWebgl2Supported = (() => {
 
 const getTermOptions = (props: TermProps): ITerminalOptions => {
   // Set a background color only if it is opaque
-  const needTransparency = Color(props.backgroundColor).alpha() < 1;
+  const needTransparency = true;
   const backgroundColor = needTransparency ? 'transparent' : props.backgroundColor;
 
   return {

--- a/lib/config.d.ts
+++ b/lib/config.d.ts
@@ -1,4 +1,5 @@
 import {FontWeight} from 'xterm';
+import {Vibrancy} from 'electron-acrylic-window';
 
 export type ColorMap = {
   black: string;
@@ -63,6 +64,7 @@ export type configOptions = {
   webGLRenderer: boolean;
   webLinksActivationKey: 'ctrl' | 'alt' | 'meta' | 'shift';
   windowSize: [number, number];
+  vibrancy: Vibrancy;
 };
 
 export type rawConfig = {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "color": "3.1.3",
     "columnify": "1.5.4",
     "css-loader": "5.2.6",
+    "electron-acrylic-window": "^0.5.5",
     "got": "11.8.2",
     "json-loader": "0.5.7",
     "mousetrap": "chabou/mousetrap#useCapture",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1825,6 +1825,13 @@ binary-extensions@^2.0.0:
   resolved "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz#30fa40c9e7fe07dbc895678cd287024dea241dd9"
   integrity sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==
 
+bindings@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz#10353c9e945334bc0511a6d90b38fbc7c9c504df"
+  integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
+  dependencies:
+    file-uri-to-path "1.0.0"
+
 bl@^4.0.3, bl@^4.1.0:
   version "4.1.0"
   resolved "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz#451535264182bec2fbbc83a62ab98cf11d9f7b3a"
@@ -3027,6 +3034,16 @@ ejs@^3.1.6:
   dependencies:
     jake "^10.6.1"
 
+electron-acrylic-window@^0.5.5:
+  version "0.5.5"
+  resolved "https://registry.npmjs.org/electron-acrylic-window/-/electron-acrylic-window-0.5.5.tgz#9c7e5dcdd38f11889f4fd95fac87bff9e20880f7"
+  integrity sha512-EGIOOYA1Su91fmAj2fjeStTvhW1FsGKXvsq1XtuIl9WXiOkVSXhR1mMwRruYqRncxzApUnDmOp6yEyiW8FRNuA==
+  dependencies:
+    bindings "^1.5.0"
+    node-addon-api "^3.1.0"
+    node-gyp "^7.1.2"
+    win32-displayconfig "^0.1.0"
+
 electron-builder@^22.11.5:
   version "22.11.5"
   resolved "https://registry.npmjs.org/electron-builder/-/electron-builder-22.11.5.tgz#914d8183e1bab7cda43ef1d67fc3d17314c7e242"
@@ -3704,6 +3721,11 @@ file-entry-cache@^6.0.1:
   dependencies:
     flat-cache "^3.0.4"
 
+file-uri-to-path@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
+  integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
+
 filelist@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/filelist/-/filelist-1.0.1.tgz#f10d1a3ae86c1694808e8f20906f43d4c9132dbb"
@@ -4131,7 +4153,7 @@ got@^9.6.0:
     to-readable-stream "^1.0.0"
     url-parse-lax "^3.0.0"
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.3, graceful-fs@^4.2.4, graceful-fs@^4.2.6:
+graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.2, graceful-fs@^4.2.3, graceful-fs@^4.2.4, graceful-fs@^4.2.6:
   version "4.2.6"
   resolved "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz#ff040b2b0853b23c3d31027523706f1885d76bee"
   integrity sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==
@@ -5754,7 +5776,7 @@ node-abi@^2.19.2:
   dependencies:
     semver "^5.4.1"
 
-node-addon-api@3.2.1:
+node-addon-api@3.2.1, node-addon-api@^3.0.0, node-addon-api@^3.1.0:
   version "3.2.1"
   resolved "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz#81325e0a2117789c0128dab65e7e38f07ceba161"
   integrity sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==
@@ -5785,7 +5807,24 @@ node-gyp@8.1.0:
     tar "^6.1.0"
     which "^2.0.2"
 
-node-gyp@^7.1.0:
+node-gyp@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.npmjs.org/node-gyp/-/node-gyp-6.1.0.tgz#64e31c61a4695ad304c1d5b82cf6b7c79cc79f3f"
+  integrity sha512-h4A2zDlOujeeaaTx06r4Vy+8MZ1679lU+wbCKDS4ZtvY2A37DESo37oejIw0mtmR3+rvNwts5B6Kpt1KrNYdNw==
+  dependencies:
+    env-paths "^2.2.0"
+    glob "^7.1.4"
+    graceful-fs "^4.2.2"
+    mkdirp "^0.5.1"
+    nopt "^4.0.1"
+    npmlog "^4.1.2"
+    request "^2.88.0"
+    rimraf "^2.6.3"
+    semver "^5.7.1"
+    tar "^4.4.12"
+    which "^1.3.1"
+
+node-gyp@^7.1.0, node-gyp@^7.1.2:
   version "7.1.2"
   resolved "https://registry.npmjs.org/node-gyp/-/node-gyp-7.1.2.tgz#21a810aebb187120251c3bcec979af1587b188ae"
   integrity sha512-CbpcIo7C3eMu3dL1c3d0xw449fHIGALIJsRP4DDPHpyiW8vcriNY7ubh9TE4zEKfSxscY7PjeFnshE7h75ynjQ==
@@ -6831,7 +6870,7 @@ repeat-string@^1.6.1:
   resolved "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
   integrity sha1-jcrkcOHIirwtYA//Sndihtp15jc=
 
-request@^2.88.2:
+request@^2.88.0, request@^2.88.2:
   version "2.88.2"
   resolved "https://registry.npmjs.org/request/-/request-2.88.2.tgz#d73c918731cb5a87da047e207234146f664d12b3"
   integrity sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==
@@ -6964,7 +7003,7 @@ rgb2hex@0.2.3:
   resolved "https://registry.npmjs.org/rgb2hex/-/rgb2hex-0.2.3.tgz#8aa464c517b8a26c7a79d767dabaec2b49ee78ec"
   integrity sha512-clEe0m1xv+Tva1B/TOepuIcvLAxP0U+sCDfgt1SX1HmI2Ahr5/Cd/nzJM1e78NKVtWdoo0s33YehpFA8UfIShQ==
 
-rimraf@^2.6.1, rimraf@^2.7.1:
+rimraf@^2.6.1, rimraf@^2.6.3, rimraf@^2.7.1:
   version "2.7.1"
   resolved "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
@@ -7086,7 +7125,7 @@ semver-diff@^3.1.1:
   dependencies:
     semver "^6.3.0"
 
-"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5.1, semver@^5.6.0:
+"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5.1, semver@^5.6.0, semver@^5.7.1:
   version "5.7.1"
   resolved "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
@@ -7692,7 +7731,7 @@ tar-stream@^2.1.4:
     inherits "^2.0.3"
     readable-stream "^3.1.1"
 
-tar@^4:
+tar@^4, tar@^4.4.12:
   version "4.4.13"
   resolved "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
   integrity sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==
@@ -8298,6 +8337,13 @@ which-boxed-primitive@^1.0.2:
     is-string "^1.0.5"
     is-symbol "^1.0.3"
 
+which@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.npmjs.org/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
+  integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
+  dependencies:
+    isexe "^2.0.0"
+
 which@^2.0.1, which@^2.0.2:
   version "2.0.2"
   resolved "https://registry.npmjs.org/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
@@ -8323,6 +8369,15 @@ wildcard@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/wildcard/-/wildcard-2.0.0.tgz#a77d20e5200c6faaac979e4b3aadc7b3dd7f8fec"
   integrity sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==
+
+win32-displayconfig@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.npmjs.org/win32-displayconfig/-/win32-displayconfig-0.1.0.tgz#eee34cb7ad82060fa2192a4c9d8e1200bfa47fe1"
+  integrity sha512-a9+QjHU7RCwOZRiTr42uWNfWQIaWQjr9TtU3dgTA05T2g4ZXgmzv99Y4kywDaInMWpXMzOOHNS4ZvhTKAO/3rA==
+  dependencies:
+    bindings "^1.5.0"
+    node-addon-api "^3.0.0"
+    node-gyp "^6.1.0"
 
 word-wrap@^1.2.3:
   version "1.2.3"


### PR DESCRIPTION
Vibrancy isn't supported by electrons on any platform other than MacOS. I found some years old discussions about the feature being possible and also some comments asserting that changing the opacity is good enough (it's not :P).

In my pursuit for vibrancy, I discovered https://github.com/Seo-Rii/electron-acrylic-window which is a wrapper for electron's `BrowserWindow` that changes the vibrancy property to be of a more complex type than just strings and works only on Windows.

I'm certain there is a better way to integrate this but I've only hacked this together and this definitely needs some polish before being considered for merging.

Importantly for these changes to work, after `yarn` is run you'll need to modify `node_modules/electron-acrylic-window/build_ts/browserWindow.d.ts:67:5` to change:

```
    setVibrancy(options?: Vibrancy): void;
```

to

```
    setVibrancy(options?: Vibrancy | null): void;
```

This works for me locally as a hack to be able to use these changes, but I'm not sure the correct path forward (or if there is one that can be done without submitting a PR to 'electron-acrylic-window' also.)

Other changes that probably need to go into this before it can be merged:

* Vibrancy shouldn't be always enabled like it is in the original changes
* a better conditional for `needTransparency`

<!-- Hi there! Thanks for submitting a PR! We're excited to see what you've got for us.

- To help whoever reviews your PR, it'd be extremely helpful for you to list whether your PR is ready to be merged,
If there's anything left to do and if there are any related PRs
- It'd also be extremely helpful to enable us to update your PR incase we need to rebase or what-not by checking `Allow edits from maintainers`
- If your PR changes some API, please make a PR for hyper website too: https://github.com/vercel/hyper-site.

Thanks, again! -->
