### PR TITLE
Fix file/directory drag and drop

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -18,7 +18,6 @@
     "electron-fetch": "1.7.3",
     "electron-is-dev": "2.0.0",
     "electron-store": "8.0.0",
-    "file-uri-to-path": "2.0.0",
     "fs-extra": "10.0.0",
     "git-describe": "4.0.4",
     "lodash": "4.17.21",

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -244,11 +244,6 @@ fast-deep-equal@^3.1.1:
   resolved "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
-file-uri-to-path@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-2.0.0.tgz#7b415aeba227d575851e0a5b0c640d7656403fba"
-  integrity sha512-hjPFI8oE/2iQPVe4gbrJ73Pp+Xfub2+WI2LlXDbsaJBwT5wuMh35WNWVYYTpnz895shtwfyutMFLFywpQAFdLg==
-
 fill-range@^7.0.1:
   version "7.0.1"
   resolved "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz#1919a6a7c75fe38b2c7c77e5198535da9acdda40"


### PR DESCRIPTION
Fixes #5305

`new-window` event is getting triggered on file drag drop to the terminal instead of `will-navigate`

Also switched from `file-uri-to path` lib to `fileURLToPath` function from `url` lib
xterm link clicks are handled using the web links addon and link providers so no need to open web links from here.