### PR TITLE
add emoji input on mac (hacky)

### DIFF
--- a/lib/components/term.tsx
+++ b/lib/components/term.tsx
@@ -239,6 +239,11 @@ export default class Term extends React.PureComponent<TermProps> {
       capture: true
     });
 
+    this.term.element?.addEventListener('textInput', this.onEmojiInput);
+    this.disposableListeners.push({
+      dispose: () => this.term.element?.removeEventListener('textInput', this.onEmojiInput)
+    });
+
     terms[this.props.uid] = this;
   }
 
@@ -252,6 +257,15 @@ export default class Term extends React.PureComponent<TermProps> {
     );
     return document;
   }
+
+  onEmojiInput = (event: Event) => {
+    const data: string = (event as any).data;
+    if (/\p{Extended_Pictographic}/u.test(data)) {
+      event.preventDefault();
+      event.stopPropagation();
+      this.term.paste(data);
+    }
+  };
 
   // intercepting paste event for any necessary processing of
   // clipboard data, if result is falsy, paste event continues


### PR DESCRIPTION
Fixes #5782 
Fixes #4556 
Add emoji input by listening to `textInput` events on terminal, and pasting the event data if it contains emoji. A bit hacky I guess. Will have to check if it works or breaks something else on other platforms.