### PR TITLE
Allow ligatures in WebGL

### DIFF
--- a/lib/components/term.tsx
+++ b/lib/components/term.tsx
@@ -176,7 +176,7 @@ export default class Term extends React.PureComponent<TermProps> {
       if (useWebGL) {
         this.term.loadAddon(new WebglAddon());
       }
-      if (props.disableLigatures !== true && !useWebGL) {
+      if (props.disableLigatures !== true) {
         this.term.loadAddon(new LigaturesAddon());
       }
       this.term.loadAddon(new Unicode11Addon());


### PR DESCRIPTION
Adds ligature support for WebGL renderer.

Fixes #3607