### PR TITLE
Add instructions on how to install `hyper-deb` for Ubuntu and Debian using Pacstall

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,13 @@ Hyper is available as [Nix package](https://github.com/NixOS/nixpkgs/blob/master
 nix-env -i hyper
 ```
 
+#### Debian/Ubuntu
+Hyper is available in [Pacstall](https://github.com/pacstall/pacstall-programs/blob/master/packages/hyper-deb/hyper-deb.pacscript). Installation instructions are [here](https://github.com/pacstall/pacstall#installing)
+
+```sh
+pacstall -I hyper-deb
+```
+
 ### macOS
 
 Use [Homebrew Cask](https://brew.sh) to download the app by running these commands:


### PR DESCRIPTION
[Pacstall](https://github.com/pacstall/pacstall) is a community-driven AUR-like package manager for Ubuntu. I am the maintainer (and the main developer of Pacstall) of the [hyper-deb](https://github.com/pacstall/pacstall-programs/blob/master/packages/hyper-deb/hyper-deb.pacscript) pacscript (similar to a PKGBUILD) in this repository. With this script, people can install and update Hyper without having to go to the download's section on GitHub every update

It can be installed on Ubuntu and Debian by running this command (after Pacstall is installed)
```bash
pacstall -I hyper-deb
```

It can also be upgraded
```bash
pacstall -Up
```
and removed when requested.
```bash
pacstall -R hyper-deb
```
