### PR TITLE
Set build_id_links as none for rpm

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -120,7 +120,11 @@
     "afterInstall": "./build/linux/after-install.tpl"
   },
   "rpm": {
-    "afterInstall": "./build/linux/after-install.tpl"
+    "afterInstall": "./build/linux/after-install.tpl",
+    "fpm": [
+      "--rpm-rpmbuild-define",
+      "_build_id_links none"
+    ]
   },
   "snap": {
     "confinement": "classic",


### PR DESCRIPTION
Avoid build-id conflicts with other electron rpm packages
Fixes #6227 

<!-- Hi there! Thanks for submitting a PR! We're excited to see what you've got for us.

- To help whoever reviews your PR, it'd be extremely helpful for you to list whether your PR is ready to be merged,
If there's anything left to do and if there are any related PRs
- It'd also be extremely helpful to enable us to update your PR incase we need to rebase or what-not by checking `Allow edits from maintainers`
- If your PR changes some API, please make a PR for hyper website too: https://github.com/vercel/hyper-site.

Thanks, again! -->
