### PR TITLE
Revert "Use desktopCapturer instead of capturePage for e2e"

### DIFF
--- a/test/index.ts
+++ b/test/index.ts
@@ -37,15 +37,11 @@ test.before(async () => {
 
 test.after(async () => {
   await app
-    .evaluate(async ({BrowserWindow, desktopCapturer, screen}) => {
-      // eslint-disable-next-line prefer-const
-      let {width, height, ...position} = BrowserWindow.getFocusedWindow()!.getBounds();
-      const {scaleFactor} = screen.getDisplayNearestPoint(position);
-      width *= scaleFactor;
-      height *= scaleFactor;
-      const sources = await desktopCapturer.getSources({types: ['window'], thumbnailSize: {width, height}});
-      return sources[0].thumbnail.toPNG().toString('base64');
-    })
+    .evaluate(({BrowserWindow}) =>
+      BrowserWindow.getFocusedWindow()
+        ?.capturePage()
+        .then((img) => img.toPNG().toString('base64'))
+    )
     .then((img) => Buffer.from(img || '', 'base64'))
     .then(async (imageBuffer) => {
       await fs.writeFile(`dist/tmp/${process.platform}_test.png`, imageBuffer);


### PR DESCRIPTION
This reverts commit a0126c4f4434188d549d5953c9299f48991cea2d.

<!-- Hi there! Thanks for submitting a PR! We're excited to see what you've got for us.

- To help whoever reviews your PR, it'd be extremely helpful for you to list whether your PR is ready to be merged,
If there's anything left to do and if there are any related PRs
- It'd also be extremely helpful to enable us to update your PR incase we need to rebase or what-not by checking `Allow edits from maintainers`
- If your PR changes some API, please make a PR for hyper website too: https://github.com/vercel/hyper-site.

Thanks, again! -->

Content was not visible in screenshot on macOS since moving to WebGL