### PR TITLE
Add support for Linux armhf i.e; armv7l

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -23,6 +23,7 @@
         "target": "deb",
         "arch": [
           "x64",
+          "armv7l",
           "arm64"
         ]
       },
@@ -30,6 +31,7 @@
         "target": "AppImage",
         "arch": [
           "x64",
+          "armv7l",
           "arm64"
         ]
       },
@@ -37,6 +39,7 @@
         "target": "rpm",
         "arch": [
           "x64",
+          "armv7l",
           "arm64"
         ]
       },


### PR DESCRIPTION
<!-- Hi there! Thanks for submitting a PR! We're excited to see what you've got for us.

- To help whoever reviews your PR, it'd be extremely helpful for you to list whether your PR is ready to be merged,
If there's anything left to do and if there are any related PRs
- It'd also be extremely helpful to enable us to update your PR incase we need to rebase or what-not by checking `Allow edits from maintainers`
- If your PR changes some API, please make a PR for hyper website too: https://github.com/vercel/hyper-site.

Thanks, again! -->

electron builder can build armv7l on x64 so this commit adds support for linux armhf devices such as raspberrypi
Closes #2820 