### PR TITLE
chore: replace deprecated String.prototype.substr()

### DIFF
--- a/app/utils/to-electron-background-color.ts
+++ b/app/utils/to-electron-background-color.ts
@@ -13,5 +13,5 @@ export default (bgColor: string) => {
 
   // http://stackoverflow.com/a/11019879/1202488
   const alphaHex = Math.round(color.alpha() * 255).toString(16);
-  return `#${alphaHex}${color.hex().toString().substr(1)}`;
+  return `#${alphaHex}${color.hex().toString().slice(1)}`;
 };


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.