### PR TITLE
Git CI Publish to Snap Store

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -79,3 +79,10 @@ jobs:
         with:
           name: pr_num
           path: ./pr_num.txt
+      - name: Publish to Snap Store
+        run: |
+            sudo snap install snapcraft --classic
+            echo "$SNAP_TOKEN" | snapcraft login --with -
+            snapcraft upload --release=stable ./dist/*.snap
+        env:
+          SNAP_TOKEN: ${{secrets.SNAP_TOKEN}}


### PR DESCRIPTION
Publish to snap store for github CI.

Requires snap developer token to be put to git CI as $SNAP_TOKEN

Changes based other electron app:
https://github.com/hovancik/stretchly/pull/1122

( docs: https://snapcraft.io/docs/releasing-your-app
CI login:
https://forum.snapcraft.io/t/how-to-log-in-to-snapcraft-with-only-1-command/11871/3
and
https://forum.snapcraft.io/t/how-to-release-to-channel-stable-with-travis-ci/21212/11 )

