### PR TITLE
Bash or ZSH child process should close without prompt

### DIFF
--- a/app/index.ts
+++ b/app/index.ts
@@ -17,7 +17,7 @@ remoteInitialize();
 import {resolve} from 'path';
 
 // Packages
-import {app, BrowserWindow, Menu, screen} from 'electron';
+import {app, BrowserWindow, Menu, dialog, screen} from 'electron';
 import {gitDescribe} from 'git-describe';
 import isDev from 'electron-is-dev';
 import * as config from './config';
@@ -30,6 +30,8 @@ import {installCLI} from './utils/cli-install';
 import * as AppMenu from './menus/menu';
 import {newWindow} from './ui/window';
 import * as windowUtils from './utils/window-utils';
+import Session from './session';
+import {readFileSync} from 'fs';
 
 const windowSet = new Set<BrowserWindow>([]);
 
@@ -138,8 +140,48 @@ app.on('ready', () =>
         windowSet.add(hwin);
         void hwin.loadURL(url);
 
+        const sessionHasRunningChildren = (session: Session): boolean => {
+          if (process.platform == 'linux') {
+            if (session.pty != null) {
+              const childProcInfoPath = `/proc/${session.pty.pid}/task/${session.pty.pid}/children`;
+              const childId = readFileSync(childProcInfoPath, 'utf8').trim();
+              const childStatus = `/proc/${childId}/task/${childId}/status`;
+              const childName = readFileSync(childStatus, 'utf8').split('\n')[0].split(':')[1].trim();
+              console.log(childName);
+              if (childName === 'bash' || childName === 'zsh') {
+                process.kill(Number(childId), 'SIGSTOP');
+                return false;
+              } else {
+                return true;
+              }
+            } else {
+              return false;
+            }
+          } else {
+            return false;
+          }
+        };
+
         // the window can be closed by the browser process itself
-        hwin.on('close', () => {
+        hwin.on('close', (evt) => {
+          for (const s of hwin.sessions.values()) {
+            const session: Session = s;
+            if (sessionHasRunningChildren(session)) {
+              // todo: focus the window/pane that has a child running in the foreground?
+              const opt = dialog.showMessageBoxSync(hwin, {
+                title: 'Close window & all terminals?',
+                buttons: ['Close terminal', 'Cancel'],
+                message: `There is still a process running in a hyper terminal. Closing the terminal will kill it.`
+              });
+              if (opt == 1) {
+                evt.preventDefault();
+                return;
+              } else {
+                hwin.clean();
+                windowSet.delete(hwin);
+              }
+            }
+          }
           hwin.clean();
           windowSet.delete(hwin);
         });


### PR DESCRIPTION

This is an improvement to the already open PR #6042 by @theIDinside.

The terminal used to close in case we made a switch from zsh to bash or vice-versa. This is a simple fix added to resolve the issue.
