### PR TITLE
Enable shortcut for editor:paste on Windows/Linux

### DIFF
--- a/app/menus/menus/edit.ts
+++ b/app/menus/menus/edit.ts
@@ -31,7 +31,8 @@ export default (
     } as any,
     {
       role: 'paste',
-      accelerator: commandKeys['editor:paste']
+      accelerator: commandKeys['editor:paste'],
+      registerAccelerator: true
     },
     {
       label: 'Select All',


### PR DESCRIPTION
fixes #3825

In the edit menu, the `registerAccelerator` was not set to true, which caused the shortcut to not be enabled.
I have confirmed that it works on Linux.