### PR TITLE
Replace 'i.e.' with 'e.g.' for examples

### DIFF
--- a/lib/config.d.ts
+++ b/lib/config.d.ts
@@ -119,7 +119,7 @@ export type configOptions = {
   /** terminal selection color */
   selectionColor: string;
   /**
-   * the shell to run when spawning a new session (i.e. /usr/local/bin/fish)
+   * the shell to run when spawning a new session (e.g. /usr/local/bin/fish)
    * if left empty, your system's login shell will be used by default
    *
    * Windows
@@ -144,7 +144,7 @@ export type configOptions = {
    */
   shell: string;
   /**
-   * for setting shell arguments (i.e. for using interactive shellArgs: `['-i']`)
+   * for setting shell arguments (e.g. for using interactive shellArgs: `['-i']`)
    * by default `['--login']` will be used
    */
   shellArgs: string[];


### PR DESCRIPTION
Very simple grammar fix. Ready to merge.
