### PR TITLE
Add hotkey for windows explorer context menu entry

### DIFF
--- a/build/win/installer.nsh
+++ b/build/win/installer.nsh
@@ -1,13 +1,13 @@
 !macro customInstall
-  WriteRegStr HKCU "Software\Classes\Directory\Background\shell\Hyper" "" "Open Hyper here"
+  WriteRegStr HKCU "Software\Classes\Directory\Background\shell\Hyper" "" "Open &Hyper here"
   WriteRegStr HKCU "Software\Classes\Directory\Background\shell\Hyper" "Icon" "$appExe"
   WriteRegStr HKCU "Software\Classes\Directory\Background\shell\Hyper\command" "" `$appExe "%V"`
 
-  WriteRegStr HKCU "Software\Classes\Directory\shell\Hyper" "" "Open Hyper here"
+  WriteRegStr HKCU "Software\Classes\Directory\shell\Hyper" "" "Open &Hyper here"
   WriteRegStr HKCU "Software\Classes\Directory\shell\Hyper" "Icon" "$appExe"
   WriteRegStr HKCU "Software\Classes\Directory\shell\Hyper\command" "" `$appExe "%V"`
 
-  WriteRegStr HKCU "Software\Classes\Drive\shell\Hyper" "" "Open Hyper here"
+  WriteRegStr HKCU "Software\Classes\Drive\shell\Hyper" "" "Open &Hyper here"
   WriteRegStr HKCU "Software\Classes\Drive\shell\Hyper" "Icon" "$appExe"
   WriteRegStr HKCU "Software\Classes\Drive\shell\Hyper\command" "" `$appExe "%V"`
 !macroend


### PR DESCRIPTION
Added the ampersand to the registry entry to give it the shortcut of "<u>H</u>" in windows. - in short Shift+F10 gives advanced options and "Open Hyper here now has the the H underlined and marked as hotkey. This is a small feature -I already manually found and updated the registry entries on my desktop and thought this is a small touch that adds just that bit more trust to the project. The others in the illustration below are marked at install. 

This PR is ready to be merged. - everything is done.


![hyper3](https://user-images.githubusercontent.com/81232303/230827230-23922141-92d0-4449-b80f-f454be136f74.png)

and proof that it is running on my personal computer with no bugs. 
![regedit_s78FznwmwO](https://user-images.githubusercontent.com/81232303/230827738-e090f32a-06e5-4a6d-8f38-d2abdc23694e.png)


<!-- Hi there! Thanks for submitting a PR! We're excited to see what you've got for us.

- To help whoever reviews your PR, it'd be extremely helpful for you to list whether your PR is ready to be merged,
If there's anything left to do and if there are any related PRs
- It'd also be extremely helpful to enable us to update your PR incase we need to rebase or what-not by checking `Allow edits from maintainers`
- If your PR changes some API, please make a PR for hyper website too: https://github.com/vercel/hyper-site.

Thanks, again! -->
