### PR TITLE
Downgrade electron to v22.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "copy-webpack-plugin": "11.0.0",
     "cpy-cli": "^4.2.0",
     "cross-env": "7.0.3",
-    "electron": "25.1.1",
+    "electron": "22.3.1",
     "electron-builder": "^24.4.0",
     "electron-devtools-installer": "3.2.0",
     "electron-link": "^0.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1121,10 +1121,15 @@
   resolved "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz#31b7ca6407128a3d2bbc27fe2d21b345397f6197"
   integrity sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==
 
-"@types/node@*", "@types/node@18.16.18", "@types/node@^18.11.18":
+"@types/node@*", "@types/node@18.16.18":
   version "18.16.18"
   resolved "https://registry.npmjs.org/@types/node/-/node-18.16.18.tgz#85da09bafb66d4bc14f7c899185336d0c1736390"
   integrity sha512-/aNaQZD0+iSBAGnvvN2Cx92HqE5sZCPZtx2TsK+4nvV23fFe09jVDvpArXr2j9DnYlzuU9WuoykDDc6wqvpNcw==
+
+"@types/node@^16.11.26":
+  version "16.18.36"
+  resolved "https://registry.npmjs.org/@types/node/-/node-16.18.36.tgz#0db5d7efc4760d36d0d1d22c85d1a53accd5dc27"
+  integrity sha512-8egDX8dE50XyXWH6C6PRCNkTP106DuUrvdrednFouDSmCi7IOvrqr0frznfZaHifHH/3aq/7a7v9N4wdXMqhBQ==
 
 "@types/node@^16.9.2":
   version "16.18.25"
@@ -2882,13 +2887,13 @@ electron-to-chromium@^1.4.251:
   resolved "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.254.tgz#c6203583890abf88dfc0be046cd72d3b48f8beb6"
   integrity sha512-Sh/7YsHqQYkA6ZHuHMy24e6TE4eX6KZVsZb9E/DvU1nQRIrH4BflO/4k+83tfdYvDl+MObvlqHPRICzEdC9c6Q==
 
-electron@25.1.1:
-  version "25.1.1"
-  resolved "https://registry.npmjs.org/electron/-/electron-25.1.1.tgz#b7aaf0d66a56fbbbad987c13cee108642f63bd50"
-  integrity sha512-WvFUfVsJn6YiP35UxdibYVjU2LceastyMm4SVp2bmb4XvKEvItAIiwxgm7tPC5Syl1243aRCvQLqr84sZ71pyQ==
+electron@22.3.1:
+  version "22.3.1"
+  resolved "https://registry.npmjs.org/electron/-/electron-22.3.1.tgz#a09769e6592cadbf45d7629c9143ffa2ef8a3842"
+  integrity sha512-iDltL9j12bINK3aOp8ZoGq4NFBFjJhw1AYHelbWj93XUCAIT4fdA+PRsq0aaTHg3bthLLlLRvIZVgNsZPqWcqg==
   dependencies:
     "@electron/get" "^2.0.0"
-    "@types/node" "^18.11.18"
+    "@types/node" "^16.11.26"
     extract-zip "^2.0.1"
 
 electronmon@^2.0.2:


### PR DESCRIPTION
Starting from electron v23, there seems to be some changes to how `-webkit-app-region` behaves. The tabs become unclickable if they have `-webkit-app-region: drag`. Downgrading to v22.3.1 for now. Will upgrade to newer electron versions when there is a solution for this or changing the tab ui to look more like chrome.