### PR TITLE
Add initial support for multiple profiles

### DIFF
--- a/app/config.ts
+++ b/app/config.ts
@@ -78,8 +78,30 @@ export const getConfigDir = () => {
   return cfgDir;
 };
 
+export const getDefaultProfile = () => {
+  return cfg.config.defaultProfile || cfg.config.profiles[0]?.name || 'default';
+};
+
+// get config for the default profile, keeping it for backward compatibility
 export const getConfig = () => {
-  return cfg.config;
+  return getProfileConfig(getDefaultProfile());
+};
+
+export const getProfiles = () => {
+  return cfg.config.profiles;
+};
+
+export const getProfileConfig = (profileName: string): configOptions => {
+  const {profiles, defaultProfile, ...baseConfig} = cfg.config;
+  const profileConfig = profiles.find((p) => p.name === profileName)?.config || {};
+  for (const key in profileConfig) {
+    if (typeof baseConfig[key] === 'object' && !Array.isArray(baseConfig[key])) {
+      baseConfig[key] = {...baseConfig[key], ...profileConfig[key]};
+    } else {
+      baseConfig[key] = profileConfig[key];
+    }
+  }
+  return {...baseConfig, defaultProfile, profiles};
 };
 
 export const openConfig = () => {

--- a/app/config/config-default.json
+++ b/app/config/config-default.json
@@ -62,7 +62,14 @@
     "autoUpdatePlugins": true,
     "preserveCWD": true,
     "screenReaderMode": false,
-    "imageSupport": true
+    "imageSupport": true,
+    "defaultProfile": "default",
+    "profiles": [
+      {
+        "name": "default",
+        "config": {}
+      }
+    ]
   },
   "plugins": [],
   "localPlugins": [],

--- a/app/config/init.ts
+++ b/app/config/init.ts
@@ -32,7 +32,19 @@ const _init = (userCfg: rawConfig, defaultCfg: rawConfig): parsedConfig => {
   return {
     config: (() => {
       if (userCfg?.config) {
-        return _.merge({}, defaultCfg.config, userCfg.config);
+        const conf = userCfg.config;
+        conf.defaultProfile = conf.defaultProfile || 'default';
+        conf.profiles = conf.profiles || [];
+        conf.profiles = conf.profiles.length > 0 ? conf.profiles : [{name: 'default', config: {}}];
+        conf.profiles = conf.profiles.map((p, i) => ({
+          ...p,
+          name: p.name || `profile-${i + 1}`,
+          config: p.config || {}
+        }));
+        if (!conf.profiles.map((p) => p.name).includes(conf.defaultProfile)) {
+          conf.defaultProfile = conf.profiles[0].name;
+        }
+        return _.merge({}, defaultCfg.config, conf);
       } else {
         notify('Error reading configuration: `config` key is missing');
         return defaultCfg.config || ({} as configOptions);

--- a/app/config/schema.json
+++ b/app/config/schema.json
@@ -24,237 +24,15 @@
                 }
             ],
             "description": "A string or number representing text font weight."
-        }
-    },
-    "properties": {
-        "config": {
+        },
+        "Partial<profileConfigOptions>": {
             "properties": {
-                "autoUpdatePlugins": {
-                    "description": "if `true` (default), Hyper will update plugins every 5 hours\nyou can also set it to a custom time e.g. `1d` or `2h`",
-                    "type": [
-                        "string",
-                        "boolean"
-                    ]
-                },
-                "backgroundColor": {
-                    "description": "terminal background color\n\nopacity is only supported on macOS",
-                    "type": "string"
-                },
-                "bell": {
-                    "description": "Supported Options:\n1. 'SOUND' -> Enables the bell as a sound\n2. false: turns off the bell",
-                    "type": "string"
-                },
-                "bellSound": {
-                    "description": "base64 encoded string of the sound file to use for the bell\nif null, the default bell will be used",
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "bellSoundURL": {
-                    "description": "An absolute file path to a sound file on the machine.",
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "borderColor": {
-                    "description": "border color (window, tabs)",
-                    "type": "string"
-                },
-                "colors": {
-                    "description": "the full list. if you're going to provide the full color palette,\nincluding the 6 x 6 color cubes and the grayscale map, just provide\nan array here instead of a color map object",
-                    "properties": {
-                        "black": {
-                            "type": "string"
-                        },
-                        "blue": {
-                            "type": "string"
-                        },
-                        "cyan": {
-                            "type": "string"
-                        },
-                        "green": {
-                            "type": "string"
-                        },
-                        "lightBlack": {
-                            "type": "string"
-                        },
-                        "lightBlue": {
-                            "type": "string"
-                        },
-                        "lightCyan": {
-                            "type": "string"
-                        },
-                        "lightGreen": {
-                            "type": "string"
-                        },
-                        "lightMagenta": {
-                            "type": "string"
-                        },
-                        "lightRed": {
-                            "type": "string"
-                        },
-                        "lightWhite": {
-                            "type": "string"
-                        },
-                        "lightYellow": {
-                            "type": "string"
-                        },
-                        "magenta": {
-                            "type": "string"
-                        },
-                        "red": {
-                            "type": "string"
-                        },
-                        "white": {
-                            "type": "string"
-                        },
-                        "yellow": {
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "black",
-                        "blue",
-                        "cyan",
-                        "green",
-                        "lightBlack",
-                        "lightBlue",
-                        "lightCyan",
-                        "lightGreen",
-                        "lightMagenta",
-                        "lightRed",
-                        "lightWhite",
-                        "lightYellow",
-                        "magenta",
-                        "red",
-                        "white",
-                        "yellow"
-                    ],
-                    "type": "object"
-                },
-                "copyOnSelect": {
-                    "description": "if `true` selected text will automatically be copied to the clipboard",
-                    "type": "boolean"
-                },
-                "css": {
-                    "description": "custom CSS to embed in the main window",
-                    "type": "string"
-                },
-                "cursorAccentColor": {
-                    "description": "terminal text color under BLOCK cursor",
-                    "type": "string"
-                },
-                "cursorBlink": {
-                    "description": "set to `true` for blinking cursor",
-                    "type": "boolean"
-                },
-                "cursorColor": {
-                    "description": "terminal cursor background color and opacity (hex, rgb, hsl, hsv, hwb or cmyk)",
-                    "type": "string"
-                },
-                "cursorShape": {
-                    "description": "`'BEAM'` for |, `'UNDERLINE'` for _, `'BLOCK'` for █",
-                    "enum": [
-                        "BEAM",
-                        "BLOCK",
-                        "UNDERLINE"
-                    ],
-                    "type": "string"
-                },
-                "defaultSSHApp": {
-                    "description": "if `true` hyper will be set as the default protocol client for SSH",
-                    "type": "boolean"
-                },
-                "disableAutoUpdates": {
-                    "description": "if `true` hyper will not check for updates",
-                    "type": "boolean"
-                },
-                "disableLigatures": {
-                    "description": "if `false` Hyper will use ligatures provided by some fonts",
-                    "type": "boolean"
-                },
                 "env": {
                     "additionalProperties": {
                         "type": "string"
                     },
                     "description": "for environment variables",
                     "type": "object"
-                },
-                "fontFamily": {
-                    "description": "font family with optional fallbacks",
-                    "type": "string"
-                },
-                "fontSize": {
-                    "description": "default font size in pixels for all tabs",
-                    "type": "number"
-                },
-                "fontWeight": {
-                    "$ref": "#/definitions/FontWeight",
-                    "description": "default font weight eg:'normal', '400', 'bold'"
-                },
-                "fontWeightBold": {
-                    "$ref": "#/definitions/FontWeight",
-                    "description": "font weight for bold characters eg:'normal', '600', 'bold'"
-                },
-                "foregroundColor": {
-                    "description": "color of the text",
-                    "type": "string"
-                },
-                "imageSupport": {
-                    "description": "Whether to enable Sixel and iTerm2 inline image protocol support or not.",
-                    "type": "boolean"
-                },
-                "letterSpacing": {
-                    "description": "letter spacing as a relative unit",
-                    "type": "number"
-                },
-                "lineHeight": {
-                    "description": "line height as a relative unit",
-                    "type": "number"
-                },
-                "macOptionSelectionMode": {
-                    "description": "choose either `'vertical'`, if you want the column mode when Option key is hold during selection (Default)\nor `'force'`, if you want to force selection regardless of whether the terminal is in mouse events mode\n(inside tmux or vim with mouse mode enabled for example).",
-                    "type": "string"
-                },
-                "modifierKeys": {
-                    "properties": {
-                        "altIsMeta": {
-                            "type": "boolean"
-                        },
-                        "cmdIsMeta": {
-                            "type": "boolean"
-                        }
-                    },
-                    "required": [
-                        "altIsMeta",
-                        "cmdIsMeta"
-                    ],
-                    "type": "object"
-                },
-                "padding": {
-                    "description": "custom padding (CSS format, i.e.: `top right bottom left` or `top horizontal bottom` or `vertical horizontal` or `all`)",
-                    "type": "string"
-                },
-                "preserveCWD": {
-                    "description": "set to true to preserve working directory when creating splits or tabs",
-                    "type": "boolean"
-                },
-                "quickEdit": {
-                    "description": "if `true` on right click selected text will be copied or pasted if no\nselection is present (`true` by default on Windows and disables the context menu feature)",
-                    "type": "boolean"
-                },
-                "screenReaderMode": {
-                    "description": "set to true to enable screen reading apps (like NVDA) to read the contents of the terminal",
-                    "type": "boolean"
-                },
-                "scrollback": {
-                    "type": "number"
-                },
-                "selectionColor": {
-                    "description": "terminal selection color",
-                    "type": "string"
                 },
                 "shell": {
                     "description": "the shell to run when spawning a new session (e.g. /usr/local/bin/fish)\nif left empty, your system's login shell will be used by default\n\nWindows\n- Make sure to use a full path if the binary name doesn't work\n- Remove `--login` in shellArgs\n\nWindows Subsystem for Linux (WSL) - previously Bash on Windows\n- Example: `C:\\\\Windows\\\\System32\\\\wsl.exe`\n\nGit-bash on Windows\n- Example: `C:\\\\Program Files\\\\Git\\\\bin\\\\bash.exe`\n\nPowerShell on Windows\n- Example: `C:\\\\WINDOWS\\\\System32\\\\WindowsPowerShell\\\\v1.0\\\\powershell.exe`\n\nCygwin\n- Example: `C:\\\\cygwin64\\\\bin\\\\bash.exe`\n\nGit Bash\n- Example: `C:\\\\Program Files\\\\Git\\\\git-cmd.exe`\nThen Add `--command=usr/bin/bash.exe` to shellArgs",
@@ -267,119 +45,415 @@
                     },
                     "type": "array"
                 },
-                "showHamburgerMenu": {
-                    "description": "if you're using a Linux setup which show native menus, set to false\n\ndefault: `true` on Linux, `true` on Windows, ignored on macOS",
-                    "enum": [
-                        "",
-                        false,
-                        true
-                    ]
-                },
-                "showWindowControls": {
-                    "description": "set to `false` if you want to hide the minimize, maximize and close buttons\n\nadditionally, set to `'left'` if you want them on the left, like in Ubuntu\n\ndefault: `true` on Windows and Linux, ignored on macOS",
-                    "enum": [
-                        "",
-                        false,
-                        "left",
-                        true
-                    ]
-                },
-                "termCSS": {
-                    "description": "custom CSS to embed in the terminal window",
-                    "type": "string"
-                },
-                "uiFontFamily": {
-                    "type": "string"
-                },
-                "updateChannel": {
-                    "description": "choose either `'stable'` for receiving highly polished, or `'canary'` for less polished but more frequent updates",
-                    "enum": [
-                        "canary",
-                        "stable"
-                    ],
-                    "type": "string"
-                },
-                "useConpty": {
-                    "type": "boolean"
-                },
-                "webGLRenderer": {
-                    "description": "Whether to use the WebGL renderer. Set it to false to use canvas-based\nrendering (slower, but supports transparent backgrounds)",
-                    "type": "boolean"
-                },
-                "webLinksActivationKey": {
-                    "description": "keypress required for weblink activation: [ctrl | alt | meta | shift]",
-                    "enum": [
-                        "",
-                        "alt",
-                        "ctrl",
-                        "meta",
-                        "shift"
-                    ],
-                    "type": "string"
-                },
-                "windowSize": {
-                    "description": "Initial window size in pixels",
-                    "items": [
-                        {
-                            "type": "number"
-                        },
-                        {
-                            "type": "number"
-                        }
-                    ],
-                    "maxItems": 2,
-                    "minItems": 2,
-                    "type": "array"
-                },
                 "workingDirectory": {
                     "description": "set custom startup directory (must be an absolute path)",
                     "type": "string"
                 }
             },
-            "required": [
-                "autoUpdatePlugins",
-                "backgroundColor",
-                "bell",
-                "bellSound",
-                "bellSoundURL",
-                "borderColor",
-                "colors",
-                "copyOnSelect",
-                "css",
-                "cursorAccentColor",
-                "cursorBlink",
-                "cursorColor",
-                "cursorShape",
-                "defaultSSHApp",
-                "disableAutoUpdates",
-                "disableLigatures",
-                "env",
-                "fontFamily",
-                "fontSize",
-                "fontWeight",
-                "fontWeightBold",
-                "foregroundColor",
-                "imageSupport",
-                "letterSpacing",
-                "lineHeight",
-                "macOptionSelectionMode",
-                "padding",
-                "preserveCWD",
-                "quickEdit",
-                "screenReaderMode",
-                "scrollback",
-                "selectionColor",
-                "shell",
-                "shellArgs",
-                "showHamburgerMenu",
-                "showWindowControls",
-                "termCSS",
-                "updateChannel",
-                "webGLRenderer",
-                "webLinksActivationKey",
-                "workingDirectory"
-            ],
             "type": "object"
+        },
+        "configOptions": {
+            "allOf": [
+                {
+                    "properties": {
+                        "autoUpdatePlugins": {
+                            "description": "if `true` (default), Hyper will update plugins every 5 hours\nyou can also set it to a custom time e.g. `1d` or `2h`",
+                            "type": [
+                                "string",
+                                "boolean"
+                            ]
+                        },
+                        "backgroundColor": {
+                            "description": "terminal background color\n\nopacity is only supported on macOS",
+                            "type": "string"
+                        },
+                        "bell": {
+                            "description": "Supported Options:\n1. 'SOUND' -> Enables the bell as a sound\n2. false: turns off the bell",
+                            "type": "string"
+                        },
+                        "bellSound": {
+                            "description": "base64 encoded string of the sound file to use for the bell\nif null, the default bell will be used",
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        },
+                        "bellSoundURL": {
+                            "description": "An absolute file path to a sound file on the machine.",
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        },
+                        "borderColor": {
+                            "description": "border color (window, tabs)",
+                            "type": "string"
+                        },
+                        "colors": {
+                            "description": "the full list. if you're going to provide the full color palette,\nincluding the 6 x 6 color cubes and the grayscale map, just provide\nan array here instead of a color map object",
+                            "properties": {
+                                "black": {
+                                    "type": "string"
+                                },
+                                "blue": {
+                                    "type": "string"
+                                },
+                                "cyan": {
+                                    "type": "string"
+                                },
+                                "green": {
+                                    "type": "string"
+                                },
+                                "lightBlack": {
+                                    "type": "string"
+                                },
+                                "lightBlue": {
+                                    "type": "string"
+                                },
+                                "lightCyan": {
+                                    "type": "string"
+                                },
+                                "lightGreen": {
+                                    "type": "string"
+                                },
+                                "lightMagenta": {
+                                    "type": "string"
+                                },
+                                "lightRed": {
+                                    "type": "string"
+                                },
+                                "lightWhite": {
+                                    "type": "string"
+                                },
+                                "lightYellow": {
+                                    "type": "string"
+                                },
+                                "magenta": {
+                                    "type": "string"
+                                },
+                                "red": {
+                                    "type": "string"
+                                },
+                                "white": {
+                                    "type": "string"
+                                },
+                                "yellow": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "black",
+                                "blue",
+                                "cyan",
+                                "green",
+                                "lightBlack",
+                                "lightBlue",
+                                "lightCyan",
+                                "lightGreen",
+                                "lightMagenta",
+                                "lightRed",
+                                "lightWhite",
+                                "lightYellow",
+                                "magenta",
+                                "red",
+                                "white",
+                                "yellow"
+                            ],
+                            "type": "object"
+                        },
+                        "copyOnSelect": {
+                            "description": "if `true` selected text will automatically be copied to the clipboard",
+                            "type": "boolean"
+                        },
+                        "css": {
+                            "description": "custom CSS to embed in the main window",
+                            "type": "string"
+                        },
+                        "cursorAccentColor": {
+                            "description": "terminal text color under BLOCK cursor",
+                            "type": "string"
+                        },
+                        "cursorBlink": {
+                            "description": "set to `true` for blinking cursor",
+                            "type": "boolean"
+                        },
+                        "cursorColor": {
+                            "description": "terminal cursor background color and opacity (hex, rgb, hsl, hsv, hwb or cmyk)",
+                            "type": "string"
+                        },
+                        "cursorShape": {
+                            "description": "`'BEAM'` for |, `'UNDERLINE'` for _, `'BLOCK'` for █",
+                            "enum": [
+                                "BEAM",
+                                "BLOCK",
+                                "UNDERLINE"
+                            ],
+                            "type": "string"
+                        },
+                        "defaultSSHApp": {
+                            "description": "if `true` hyper will be set as the default protocol client for SSH",
+                            "type": "boolean"
+                        },
+                        "disableAutoUpdates": {
+                            "description": "if `true` hyper will not check for updates",
+                            "type": "boolean"
+                        },
+                        "disableLigatures": {
+                            "description": "if `false` Hyper will use ligatures provided by some fonts",
+                            "type": "boolean"
+                        },
+                        "fontFamily": {
+                            "description": "font family with optional fallbacks",
+                            "type": "string"
+                        },
+                        "fontSize": {
+                            "description": "default font size in pixels for all tabs",
+                            "type": "number"
+                        },
+                        "fontWeight": {
+                            "$ref": "#/definitions/FontWeight",
+                            "description": "default font weight eg:'normal', '400', 'bold'"
+                        },
+                        "fontWeightBold": {
+                            "$ref": "#/definitions/FontWeight",
+                            "description": "font weight for bold characters eg:'normal', '600', 'bold'"
+                        },
+                        "foregroundColor": {
+                            "description": "color of the text",
+                            "type": "string"
+                        },
+                        "imageSupport": {
+                            "description": "Whether to enable Sixel and iTerm2 inline image protocol support or not.",
+                            "type": "boolean"
+                        },
+                        "letterSpacing": {
+                            "description": "letter spacing as a relative unit",
+                            "type": "number"
+                        },
+                        "lineHeight": {
+                            "description": "line height as a relative unit",
+                            "type": "number"
+                        },
+                        "macOptionSelectionMode": {
+                            "description": "choose either `'vertical'`, if you want the column mode when Option key is hold during selection (Default)\nor `'force'`, if you want to force selection regardless of whether the terminal is in mouse events mode\n(inside tmux or vim with mouse mode enabled for example).",
+                            "type": "string"
+                        },
+                        "modifierKeys": {
+                            "properties": {
+                                "altIsMeta": {
+                                    "type": "boolean"
+                                },
+                                "cmdIsMeta": {
+                                    "type": "boolean"
+                                }
+                            },
+                            "required": [
+                                "altIsMeta",
+                                "cmdIsMeta"
+                            ],
+                            "type": "object"
+                        },
+                        "padding": {
+                            "description": "custom padding (CSS format, i.e.: `top right bottom left` or `top horizontal bottom` or `vertical horizontal` or `all`)",
+                            "type": "string"
+                        },
+                        "preserveCWD": {
+                            "description": "set to true to preserve working directory when creating splits or tabs",
+                            "type": "boolean"
+                        },
+                        "quickEdit": {
+                            "description": "if `true` on right click selected text will be copied or pasted if no\nselection is present (`true` by default on Windows and disables the context menu feature)",
+                            "type": "boolean"
+                        },
+                        "screenReaderMode": {
+                            "description": "set to true to enable screen reading apps (like NVDA) to read the contents of the terminal",
+                            "type": "boolean"
+                        },
+                        "scrollback": {
+                            "type": "number"
+                        },
+                        "selectionColor": {
+                            "description": "terminal selection color",
+                            "type": "string"
+                        },
+                        "showHamburgerMenu": {
+                            "description": "if you're using a Linux setup which show native menus, set to false\n\ndefault: `true` on Linux, `true` on Windows, ignored on macOS",
+                            "enum": [
+                                "",
+                                false,
+                                true
+                            ]
+                        },
+                        "showWindowControls": {
+                            "description": "set to `false` if you want to hide the minimize, maximize and close buttons\n\nadditionally, set to `'left'` if you want them on the left, like in Ubuntu\n\ndefault: `true` on Windows and Linux, ignored on macOS",
+                            "enum": [
+                                "",
+                                false,
+                                "left",
+                                true
+                            ]
+                        },
+                        "termCSS": {
+                            "description": "custom CSS to embed in the terminal window",
+                            "type": "string"
+                        },
+                        "uiFontFamily": {
+                            "type": "string"
+                        },
+                        "updateChannel": {
+                            "description": "choose either `'stable'` for receiving highly polished, or `'canary'` for less polished but more frequent updates",
+                            "enum": [
+                                "canary",
+                                "stable"
+                            ],
+                            "type": "string"
+                        },
+                        "useConpty": {
+                            "type": "boolean"
+                        },
+                        "webGLRenderer": {
+                            "description": "Whether to use the WebGL renderer. Set it to false to use canvas-based\nrendering (slower, but supports transparent backgrounds)",
+                            "type": "boolean"
+                        },
+                        "webLinksActivationKey": {
+                            "description": "keypress required for weblink activation: [ctrl | alt | meta | shift]",
+                            "enum": [
+                                "",
+                                "alt",
+                                "ctrl",
+                                "meta",
+                                "shift"
+                            ],
+                            "type": "string"
+                        },
+                        "windowSize": {
+                            "description": "Initial window size in pixels",
+                            "items": [
+                                {
+                                    "type": "number"
+                                },
+                                {
+                                    "type": "number"
+                                }
+                            ],
+                            "maxItems": 2,
+                            "minItems": 2,
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "autoUpdatePlugins",
+                        "backgroundColor",
+                        "bell",
+                        "bellSound",
+                        "bellSoundURL",
+                        "borderColor",
+                        "colors",
+                        "copyOnSelect",
+                        "css",
+                        "cursorAccentColor",
+                        "cursorBlink",
+                        "cursorColor",
+                        "cursorShape",
+                        "defaultSSHApp",
+                        "disableAutoUpdates",
+                        "disableLigatures",
+                        "fontFamily",
+                        "fontSize",
+                        "fontWeight",
+                        "fontWeightBold",
+                        "foregroundColor",
+                        "imageSupport",
+                        "letterSpacing",
+                        "lineHeight",
+                        "macOptionSelectionMode",
+                        "padding",
+                        "preserveCWD",
+                        "quickEdit",
+                        "screenReaderMode",
+                        "scrollback",
+                        "selectionColor",
+                        "showHamburgerMenu",
+                        "showWindowControls",
+                        "termCSS",
+                        "updateChannel",
+                        "webGLRenderer",
+                        "webLinksActivationKey"
+                    ],
+                    "type": "object"
+                },
+                {
+                    "properties": {
+                        "env": {
+                            "additionalProperties": {
+                                "type": "string"
+                            },
+                            "description": "for environment variables",
+                            "type": "object"
+                        },
+                        "shell": {
+                            "description": "the shell to run when spawning a new session (e.g. /usr/local/bin/fish)\nif left empty, your system's login shell will be used by default\n\nWindows\n- Make sure to use a full path if the binary name doesn't work\n- Remove `--login` in shellArgs\n\nWindows Subsystem for Linux (WSL) - previously Bash on Windows\n- Example: `C:\\\\Windows\\\\System32\\\\wsl.exe`\n\nGit-bash on Windows\n- Example: `C:\\\\Program Files\\\\Git\\\\bin\\\\bash.exe`\n\nPowerShell on Windows\n- Example: `C:\\\\WINDOWS\\\\System32\\\\WindowsPowerShell\\\\v1.0\\\\powershell.exe`\n\nCygwin\n- Example: `C:\\\\cygwin64\\\\bin\\\\bash.exe`\n\nGit Bash\n- Example: `C:\\\\Program Files\\\\Git\\\\git-cmd.exe`\nThen Add `--command=usr/bin/bash.exe` to shellArgs",
+                            "type": "string"
+                        },
+                        "shellArgs": {
+                            "description": "for setting shell arguments (e.g. for using interactive shellArgs: `['-i']`)\nby default `['--login']` will be used",
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "workingDirectory": {
+                            "description": "set custom startup directory (must be an absolute path)",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "env",
+                        "shell",
+                        "shellArgs",
+                        "workingDirectory"
+                    ],
+                    "type": "object"
+                },
+                {
+                    "properties": {
+                        "defaultProfile": {
+                            "description": "The default profile name to use when launching a new session",
+                            "type": "string"
+                        },
+                        "profiles": {
+                            "description": "A list of profiles to use",
+                            "items": {
+                                "properties": {
+                                    "config": {
+                                        "$ref": "#/definitions/Partial<profileConfigOptions>",
+                                        "description": "Specify all the options you want to override for each profile.\nOptions set here override the defaults set in the root."
+                                    },
+                                    "name": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "config",
+                                    "name"
+                                ],
+                                "type": "object"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "defaultProfile",
+                        "profiles"
+                    ],
+                    "type": "object"
+                }
+            ]
+        }
+    },
+    "properties": {
+        "config": {
+            "$ref": "#/definitions/configOptions"
         },
         "keymaps": {
             "additionalProperties": {

--- a/app/index.ts
+++ b/app/index.ts
@@ -92,7 +92,7 @@ app.on('ready', () =>
         fn?: (win: BrowserWindow) => void,
         options: {size?: [number, number]; position?: [number, number]} = {}
       ) {
-        const cfg = plugins.getDecoratedConfig();
+        const cfg = plugins.getDecoratedConfig(config.getDefaultProfile());
 
         const winSet = config.getWin();
         let [startX, startY] = winSet.position;

--- a/app/plugins.ts
+++ b/app/plugins.ts
@@ -425,8 +425,12 @@ export const getDecoratedEnv = (baseEnv: Record<string, string>) => {
   return decorateObject(baseEnv, 'decorateEnv');
 };
 
-export const getDecoratedConfig = () => {
-  const baseConfig = config.getConfig();
+export const getDefaultProfile = () => {
+  return config.getDefaultProfile();
+};
+
+export const getDecoratedConfig = (profile: string) => {
+  const baseConfig = config.getProfileConfig(profile);
   const decoratedConfig = decorateObject(baseConfig, 'decorateConfig');
   const fixedConfig = config.fixConfigDefaults(decoratedConfig);
   const translatedConfig = config.htermConfigTranslate(fixedConfig);

--- a/app/ui/window.ts
+++ b/app/ui/window.ts
@@ -20,6 +20,7 @@ import type {configOptions} from '../../lib/config';
 import {getWorkingDirectoryFromPID} from 'native-process-working-directory';
 import {existsSync} from 'fs';
 import type {sessionExtraOptions} from '../../common';
+import {getDefaultProfile} from '../config';
 
 export function newWindow(
   options_: BrowserWindowConstructorOptions,
@@ -62,7 +63,7 @@ export function newWindow(
   const sessions = new Map<string, Session>();
 
   const updateBackgroundColor = () => {
-    const cfg_ = app.plugins.getDecoratedConfig();
+    const cfg_ = app.plugins.getDecoratedConfig(getDefaultProfile());
     window.setBackgroundColor(toElectronBackgroundColor(cfg_.backgroundColor || '#000'));
   };
 
@@ -83,7 +84,7 @@ export function newWindow(
 
   // config changes
   const cfgUnsubscribe = app.config.subscribe(() => {
-    const cfg_ = app.plugins.getDecoratedConfig();
+    const cfg_ = app.plugins.getDecoratedConfig(getDefaultProfile());
 
     // notify renderer
     window.webContents.send('config change');

--- a/app/updater.ts
+++ b/app/updater.ts
@@ -8,6 +8,7 @@ import retry from 'async-retry';
 import {version} from './package.json';
 import {getDecoratedConfig} from './plugins';
 import autoUpdaterLinux from './auto-updater-linux';
+import {getDefaultProfile} from './config';
 
 const {platform} = process;
 const isLinux = platform === 'linux';
@@ -16,7 +17,7 @@ const autoUpdater: AutoUpdater = isLinux ? autoUpdaterLinux : electron.autoUpdat
 
 const getDecoratedConfigWithRetry = async () => {
   return await retry(() => {
-    const content = getDecoratedConfig();
+    const content = getDecoratedConfig(getDefaultProfile());
     if (!content) {
       throw new Error('No config content loaded');
     }

--- a/common.d.ts
+++ b/common.d.ts
@@ -10,6 +10,7 @@ export type Session = {
   shell: string | null;
   pid: number | null;
   activeUid?: string;
+  profile: string;
 };
 
 export type sessionExtraOptions = {
@@ -21,6 +22,7 @@ export type sessionExtraOptions = {
   cols?: number;
   shell?: string;
   shellArgs?: string[];
+  profile?: string;
 };
 
 export type MainEvents = {
@@ -72,9 +74,9 @@ export type RendererEvents = {
   'term selectAll': never;
   reload: never;
   'session clear req': never;
-  'split request horizontal': {activeUid?: string};
-  'split request vertical': {activeUid?: string};
-  'termgroup add req': {activeUid?: string};
+  'split request horizontal': {activeUid?: string; profile?: string};
+  'split request vertical': {activeUid?: string; profile?: string};
+  'termgroup add req': {activeUid?: string; profile?: string};
   'termgroup close req': never;
   'session add': Session;
   'session data': string;

--- a/lib/actions/sessions.ts
+++ b/lib/actions/sessions.ts
@@ -18,7 +18,7 @@ import {
 import type {HyperState, HyperDispatch, HyperActions} from '../hyper';
 import type {Session} from '../../common';
 
-export function addSession({uid, shell, pid, cols = null, rows = null, splitDirection, activeUid}: Session) {
+export function addSession({uid, shell, pid, cols = null, rows = null, splitDirection, activeUid, profile}: Session) {
   return (dispatch: HyperDispatch, getState: () => HyperState) => {
     const {sessions} = getState();
     const now = Date.now();
@@ -31,20 +31,20 @@ export function addSession({uid, shell, pid, cols = null, rows = null, splitDire
       rows,
       splitDirection,
       activeUid: activeUid ? activeUid : sessions.activeUid,
-      now
+      now,
+      profile
     });
   };
 }
 
-export function requestSession() {
+export function requestSession(profile: string | undefined) {
   return (dispatch: HyperDispatch, getState: () => HyperState) => {
     dispatch({
       type: SESSION_REQUEST,
       effect: () => {
         const {ui} = getState();
-        // the cols and rows from preview session maybe not accurate. so remove.
-        const {/*cols, rows,*/ cwd} = ui;
-        rpc.emit('new', {cwd});
+        const {cwd} = ui;
+        rpc.emit('new', {cwd, profile});
       }
     });
   };

--- a/lib/actions/term-groups.ts
+++ b/lib/actions/term-groups.ts
@@ -13,16 +13,19 @@ import {setActiveSession, ptyExitSession, userExitSession} from './sessions';
 import type {ITermState, ITermGroup, HyperState, HyperDispatch, HyperActions} from '../hyper';
 
 function requestSplit(direction: 'VERTICAL' | 'HORIZONTAL') {
-  return (activeUid: string | undefined) =>
+  return (_activeUid: string | undefined, _profile: string | undefined) =>
     (dispatch: HyperDispatch, getState: () => HyperState): void => {
       dispatch({
         type: SESSION_REQUEST,
         effect: () => {
           const {ui, sessions} = getState();
+          const activeUid = _activeUid ? _activeUid : sessions.activeUid;
+          const profile = _profile ? _profile : activeUid ? sessions.sessions[activeUid].profile : undefined;
           rpc.emit('new', {
             splitDirection: direction,
             cwd: ui.cwd,
-            activeUid: activeUid ? activeUid : sessions.activeUid
+            activeUid,
+            profile
           });
         }
       });
@@ -40,17 +43,20 @@ export function resizeTermGroup(uid: string, sizes: number[]): HyperActions {
   };
 }
 
-export function requestTermGroup(activeUid: string | undefined) {
+export function requestTermGroup(_activeUid: string | undefined, _profile: string | undefined) {
   return (dispatch: HyperDispatch, getState: () => HyperState) => {
     dispatch({
       type: TERM_GROUP_REQUEST,
       effect: () => {
         const {ui, sessions} = getState();
         const {cwd} = ui;
+        const activeUid = _activeUid ? _activeUid : sessions.activeUid;
+        const profile = _profile ? _profile : activeUid ? sessions.sessions[activeUid].profile : undefined;
         rpc.emit('new', {
           isNewGroup: true,
           cwd,
-          activeUid: activeUid ? activeUid : sessions.activeUid
+          activeUid,
+          profile
         });
       }
     });

--- a/lib/actions/ui.ts
+++ b/lib/actions/ui.ts
@@ -274,7 +274,7 @@ export function openFile(path: string) {
               });
             });
           }
-          dispatch(requestSession());
+          dispatch(requestSession(undefined));
         });
       }
     });
@@ -310,7 +310,7 @@ export function openSSH(parsedUrl: ReturnType<typeof parseUrl>) {
           });
         });
 
-        dispatch(requestSession());
+        dispatch(requestSession(undefined));
       }
     });
   };

--- a/lib/components/header.tsx
+++ b/lib/components/header.tsx
@@ -81,9 +81,13 @@ export default class Header extends React.PureComponent<HeaderProps> {
     const props = getTabsProps(this.props, {
       tabs: this.props.tabs,
       borderColor: this.props.borderColor,
+      backgroundColor: this.props.backgroundColor,
       onClose: this.props.onCloseTab,
       onChange: this.onChangeIntent,
-      fullScreen: this.props.fullScreen
+      fullScreen: this.props.fullScreen,
+      defaultProfile: this.props.defaultProfile,
+      profiles: this.props.profiles.asMutable({deep: true}),
+      openNewTab: this.props.openNewTab
     });
     const {borderColor} = props;
     let title = 'Hyper';

--- a/lib/components/new-tab.tsx
+++ b/lib/components/new-tab.tsx
@@ -1,0 +1,147 @@
+import React, {useRef, useState} from 'react';
+import {VscChevronDown} from '@react-icons/all-files/vsc/VscChevronDown';
+import type {configOptions} from '../config';
+import useClickAway from 'react-use/lib/useClickAway';
+
+interface Props {
+  defaultProfile: string;
+  profiles: configOptions['profiles'];
+  openNewTab: (name: string) => void;
+  backgroundColor: string;
+  borderColor: string;
+  tabsVisible: boolean;
+}
+const isMac = /Mac/.test(navigator.userAgent);
+
+const DropdownButton = ({defaultProfile, profiles, openNewTab, backgroundColor, borderColor, tabsVisible}: Props) => {
+  const [dropdownOpen, setDropdownOpen] = useState(false);
+  const ref = useRef(null);
+
+  const toggleDropdown = () => {
+    setDropdownOpen(!dropdownOpen);
+  };
+
+  useClickAway(ref, () => {
+    setDropdownOpen(false);
+  });
+
+  return (
+    <div
+      ref={ref}
+      title="New Tab"
+      className={`new_tab ${tabsVisible ? 'tabs_visible' : 'tabs_hidden'}`}
+      onClick={toggleDropdown}
+      onDoubleClick={(e) => e.stopPropagation()}
+      onBlur={() => setDropdownOpen(false)}
+    >
+      <VscChevronDown style={{verticalAlign: 'middle'}} />
+
+      {dropdownOpen && (
+        <ul
+          key="dropdown"
+          className="profile_dropdown"
+          style={{
+            borderColor,
+            backgroundColor
+          }}
+        >
+          {profiles.map((profile) => (
+            <li
+              key={profile.name}
+              onClick={() => {
+                openNewTab(profile.name);
+                setDropdownOpen(false);
+              }}
+              className={`profile_dropdown_item ${
+                profile.name === defaultProfile && profiles.length > 1 ? 'profile_dropdown_item_default' : ''
+              }`}
+            >
+              {profile.name}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <style jsx>{`
+        .profile_dropdown {
+          border-width: 1px;
+          border-style: solid;
+          border-bottom-width: 0px;
+          border-right-width: 0px;
+          position: absolute;
+          top: 33px;
+          right: 0px;
+          z-index: 1000;
+          padding: 0px;
+          margin: 0px;
+          list-style-type: none;
+          white-space: nowrap;
+          min-width: 120px;
+        }
+
+        .profile_dropdown_item {
+          padding: 0px 20px;
+          height: 34px;
+          line-height: 34px;
+          cursor: pointer;
+          font-size: 12px;
+          color: #fff;
+          background-color: transparent;
+          border-width: 0px;
+          border-style: solid;
+          border-color: transparent;
+          border-bottom-width: 1px;
+          border-bottom-style: solid;
+          border-bottom-color: ${borderColor};
+          text-align: start;
+          text-transform: capitalize;
+        }
+
+        .profile_dropdown_item:hover {
+          background-color: ${borderColor};
+        }
+
+        .profile_dropdown_item_default {
+          font-weight: bold;
+        }
+
+        .new_tab {
+          background: transparent;
+          color: #fff;
+          border-left: 1px;
+          border-bottom: 1px;
+          border-left-style: solid;
+          border-bottom-style: solid;
+          border-left-width: 1px;
+          border-bottom-width: 1px;
+          cursor: pointer;
+          font-size: 12px;
+          height: 34px;
+          line-height: 34px;
+          padding: 0 16px;
+          position: relative;
+          text-align: center;
+          -webkit-user-select: none;
+          ${isMac ? '-webkit-app-region: drag;' : ''}
+          top: '0px';
+        }
+
+        .tabs_visible {
+          border-color: ${borderColor};
+        }
+
+        .tabs_hidden {
+          border-color: transparent;
+          position: absolute;
+          right: 0px;
+        }
+
+        .tabs_hidden:hover {
+          border-color: ${borderColor};
+        }
+      `}</style>
+    </div>
+  );
+};
+
+export default DropdownButton;

--- a/lib/components/tabs.tsx
+++ b/lib/components/tabs.tsx
@@ -4,6 +4,7 @@ import {decorate, getTabProps} from '../utils/plugins';
 
 import Tab_ from './tab';
 import type {TabsProps} from '../hyper';
+import DropdownButton from './new-tab';
 
 const Tab = decorate(Tab_, 'Tab');
 const isMac = /Mac/.test(navigator.userAgent);
@@ -45,6 +46,7 @@ export default class Tabs extends React.PureComponent<TabsProps> {
               )
             ]
           : null}
+        <DropdownButton {...this.props} tabsVisible={tabs.length > 1} />
         {this.props.customChildren}
 
         <style jsx>{`
@@ -59,6 +61,8 @@ export default class Tabs extends React.PureComponent<TabsProps> {
             -webkit-user-select: none;
             -webkit-app-region: ${isMac ? 'drag' : ''};
             top: ${isMac ? '0px' : '34px'};
+            display: flex;
+            flex-flow: row;
           }
 
           .tabs_hiddenNav {
@@ -73,6 +77,7 @@ export default class Tabs extends React.PureComponent<TabsProps> {
             white-space: nowrap;
             padding-left: 76px;
             padding-right: 76px;
+            flex-grow: 1;
           }
 
           .tabs_list {
@@ -80,6 +85,7 @@ export default class Tabs extends React.PureComponent<TabsProps> {
             display: flex;
             flex-flow: row;
             margin-left: ${isMac ? '76px' : '0'};
+            flex-grow: 1;
           }
 
           .tabs_fullScreen {

--- a/lib/config.d.ts
+++ b/lib/config.d.ts
@@ -19,7 +19,44 @@ export type ColorMap = {
   yellow: string;
 };
 
-export type configOptions = {
+type profileConfigOptions = {
+  /** for environment variables */
+  env: {[k: string]: string};
+  /**
+   * the shell to run when spawning a new session (e.g. /usr/local/bin/fish)
+   * if left empty, your system's login shell will be used by default
+   *
+   * Windows
+   * - Make sure to use a full path if the binary name doesn't work
+   * - Remove `--login` in shellArgs
+   *
+   * Windows Subsystem for Linux (WSL) - previously Bash on Windows
+   * - Example: `C:\\Windows\\System32\\wsl.exe`
+   *
+   * Git-bash on Windows
+   * - Example: `C:\\Program Files\\Git\\bin\\bash.exe`
+   *
+   * PowerShell on Windows
+   * - Example: `C:\\WINDOWS\\System32\\WindowsPowerShell\\v1.0\\powershell.exe`
+   *
+   * Cygwin
+   * - Example: `C:\\cygwin64\\bin\\bash.exe`
+   *
+   * Git Bash
+   * - Example: `C:\\Program Files\\Git\\git-cmd.exe`
+   * Then Add `--command=usr/bin/bash.exe` to shellArgs
+   */
+  shell: string;
+  /**
+   * for setting shell arguments (e.g. for using interactive shellArgs: `['-i']`)
+   * by default `['--login']` will be used
+   */
+  shellArgs: string[];
+  /** set custom startup directory (must be an absolute path) */
+  workingDirectory: string;
+};
+
+type rootConfigOptions = {
   /**
    * if `true` (default), Hyper will update plugins every 5 hours
    * you can also set it to a custom time e.g. `1d` or `2h`
@@ -74,8 +111,6 @@ export type configOptions = {
   disableAutoUpdates: boolean;
   /** if `false` Hyper will use ligatures provided by some fonts */
   disableLigatures: boolean;
-  /** for environment variables */
-  env: {[k: string]: string};
   /** font family with optional fallbacks */
   fontFamily: string;
   /** default font size in pixels for all tabs */
@@ -123,36 +158,6 @@ export type configOptions = {
   /** terminal selection color */
   selectionColor: string;
   /**
-   * the shell to run when spawning a new session (e.g. /usr/local/bin/fish)
-   * if left empty, your system's login shell will be used by default
-   *
-   * Windows
-   * - Make sure to use a full path if the binary name doesn't work
-   * - Remove `--login` in shellArgs
-   *
-   * Windows Subsystem for Linux (WSL) - previously Bash on Windows
-   * - Example: `C:\\Windows\\System32\\wsl.exe`
-   *
-   * Git-bash on Windows
-   * - Example: `C:\\Program Files\\Git\\bin\\bash.exe`
-   *
-   * PowerShell on Windows
-   * - Example: `C:\\WINDOWS\\System32\\WindowsPowerShell\\v1.0\\powershell.exe`
-   *
-   * Cygwin
-   * - Example: `C:\\cygwin64\\bin\\bash.exe`
-   *
-   * Git Bash
-   * - Example: `C:\\Program Files\\Git\\git-cmd.exe`
-   * Then Add `--command=usr/bin/bash.exe` to shellArgs
-   */
-  shell: string;
-  /**
-   * for setting shell arguments (e.g. for using interactive shellArgs: `['-i']`)
-   * by default `['--login']` will be used
-   */
-  shellArgs: string[];
-  /**
    * if you're using a Linux setup which show native menus, set to false
    *
    * default: `true` on Linux, `true` on Windows, ignored on macOS
@@ -184,9 +189,26 @@ export type configOptions = {
   webLinksActivationKey: 'ctrl' | 'alt' | 'meta' | 'shift' | '';
   /** Initial window size in pixels */
   windowSize?: [number, number];
-  /** set custom startup directory (must be an absolute path) */
-  workingDirectory: string;
 };
+
+export type configOptions = rootConfigOptions &
+  profileConfigOptions & {
+    /**
+     * The default profile name to use when launching a new session
+     */
+    defaultProfile: string;
+    /**
+     * A list of profiles to use
+     */
+    profiles: {
+      name: string;
+      /**
+       * Specify all the options you want to override for each profile.
+       * Options set here override the defaults set in the root.
+       */
+      config: Partial<profileConfigOptions>;
+    }[];
+  };
 
 export type rawConfig = {
   config?: configOptions;

--- a/lib/constants/sessions.ts
+++ b/lib/constants/sessions.ts
@@ -22,6 +22,7 @@ export interface SessionAddAction {
   splitDirection?: 'HORIZONTAL' | 'VERTICAL';
   activeUid: string | null;
   now: number;
+  profile: string;
 }
 export interface SessionResizeAction {
   type: typeof SESSION_RESIZE;

--- a/lib/containers/header.ts
+++ b/lib/containers/header.ts
@@ -5,6 +5,7 @@ import {closeTab, changeTab, maximize, openHamburgerMenu, unmaximize, minimize, 
 import {connect} from '../utils/plugins';
 import {getRootGroups} from '../selectors';
 import type {HyperState, HyperDispatch, ITab} from '../hyper';
+import {requestTermGroup} from '../actions/term-groups';
 
 const isMac = /Mac/.test(navigator.userAgent);
 
@@ -38,7 +39,9 @@ const mapStateToProps = (state: HyperState) => {
     maximized: state.ui.maximized,
     fullScreen: state.ui.fullScreen,
     showHamburgerMenu: state.ui.showHamburgerMenu,
-    showWindowControls: state.ui.showWindowControls
+    showWindowControls: state.ui.showWindowControls,
+    defaultProfile: state.ui.defaultProfile,
+    profiles: state.ui.profiles
   };
 };
 
@@ -70,6 +73,10 @@ const mapDispatchToProps = (dispatch: HyperDispatch) => {
 
     close: () => {
       dispatch(close());
+    },
+
+    openNewTab: (profile: string) => {
+      dispatch(requestTermGroup(undefined, profile));
     }
   };
 };

--- a/lib/hyper.d.ts
+++ b/lib/hyper.d.ts
@@ -121,6 +121,7 @@ export type session = {
   uid: string;
   splitDirection?: 'HORIZONTAL' | 'VERTICAL';
   activeUid?: string;
+  profile: string;
 };
 
 export type sessionState = Immutable<{

--- a/lib/hyper.d.ts
+++ b/lib/hyper.d.ts
@@ -239,9 +239,13 @@ export type ITab = {
 export type TabsProps = {
   tabs: ITab[];
   borderColor: string;
+  backgroundColor: string;
   onChange: (uid: string) => void;
   onClose: (uid: string) => void;
   fullScreen: boolean;
+  defaultProfile: string;
+  profiles: configOptions['profiles'];
+  openNewTab: (profile: string) => void;
 } & extensionProps;
 
 export type NotificationProps = {

--- a/lib/hyper.d.ts
+++ b/lib/hyper.d.ts
@@ -39,7 +39,7 @@ export type ITermState = Immutable<{
 
 export type cursorShapes = 'BEAM' | 'UNDERLINE' | 'BLOCK';
 import type {FontWeight, IWindowsPty, Terminal} from 'xterm';
-import type {ColorMap} from './config';
+import type {ColorMap, configOptions} from './config';
 
 export type uiState = Immutable<{
   _lastUpdate: number | null;
@@ -105,6 +105,8 @@ export type uiState = Immutable<{
   webGLRenderer: boolean;
   webLinksActivationKey: 'ctrl' | 'alt' | 'meta' | 'shift' | '';
   windowsPty?: IWindowsPty;
+  defaultProfile: string;
+  profiles: configOptions['profiles'];
 }>;
 
 export type session = {

--- a/lib/index.tsx
+++ b/lib/index.tsx
@@ -156,16 +156,16 @@ rpc.on('session search close', () => {
   store_.dispatch(sessionActions.closeSearch());
 });
 
-rpc.on('termgroup add req', ({activeUid}) => {
-  store_.dispatch(termGroupActions.requestTermGroup(activeUid));
+rpc.on('termgroup add req', ({activeUid, profile}) => {
+  store_.dispatch(termGroupActions.requestTermGroup(activeUid, profile));
 });
 
-rpc.on('split request horizontal', ({activeUid}) => {
-  store_.dispatch(termGroupActions.requestHorizontalSplit(activeUid));
+rpc.on('split request horizontal', ({activeUid, profile}) => {
+  store_.dispatch(termGroupActions.requestHorizontalSplit(activeUid, profile));
 });
 
-rpc.on('split request vertical', ({activeUid}) => {
-  store_.dispatch(termGroupActions.requestVerticalSplit(activeUid));
+rpc.on('split request vertical', ({activeUid, profile}) => {
+  store_.dispatch(termGroupActions.requestVerticalSplit(activeUid, profile));
 });
 
 rpc.on('reset fontSize req', () => {

--- a/lib/reducers/sessions.ts
+++ b/lib/reducers/sessions.ts
@@ -28,7 +28,8 @@ function Session(obj: Immutable.DeepPartial<session>) {
     cleared: false,
     search: false,
     shell: '',
-    pid: null
+    pid: null,
+    profile: ''
   };
   return Immutable(x).merge(obj);
 }
@@ -51,7 +52,8 @@ const reducer: ISessionReducer = (state = initialState, action) => {
           rows: action.rows,
           uid: action.uid,
           shell: action.shell ? action.shell.split('/').pop() : null,
-          pid: action.pid
+          pid: action.pid,
+          profile: action.profile
         })
       );
 

--- a/lib/reducers/ui.ts
+++ b/lib/reducers/ui.ts
@@ -113,7 +113,9 @@ const initial: uiState = Immutable<Mutable<uiState>>({
   webLinksActivationKey: '',
   macOptionSelectionMode: 'vertical',
   disableLigatures: true,
-  screenReaderMode: false
+  screenReaderMode: false,
+  defaultProfile: '',
+  profiles: []
 });
 
 const reducer: IUiReducer = (state = initial, action) => {
@@ -285,6 +287,14 @@ const reducer: IUiReducer = (state = initial, action) => {
 
             if (config.imageSupport !== undefined) {
               ret.imageSupport = config.imageSupport;
+            }
+
+            if (config.defaultProfile !== undefined) {
+              ret.defaultProfile = config.defaultProfile;
+            }
+
+            if (config.profiles !== undefined) {
+              ret.profiles = config.profiles;
             }
 
             ret._lastUpdate = now;

--- a/lib/utils/config.ts
+++ b/lib/utils/config.ts
@@ -5,7 +5,7 @@ import {require as remoteRequire} from '@electron/remote';
 const plugins = remoteRequire('./plugins') as typeof import('../../app/plugins');
 
 export function getConfig() {
-  return plugins.getDecoratedConfig();
+  return plugins.getDecoratedConfig(plugins.getDefaultProfile());
 }
 
 export function subscribe(fn: (event: Electron.IpcRendererEvent, ...args: any[]) => void) {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "react-deep-force-update": "2.1.3",
     "react-dom": "17.0.2",
     "react-redux": "7.2.8",
+    "react-use": "^17.4.0",
     "redux": "4.2.1",
     "redux-thunk": "2.4.2",
     "registry-url": "^6.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -538,19 +538,19 @@
     "@babel/plugin-transform-modules-commonjs" "^7.22.5"
     "@babel/plugin-transform-typescript" "^7.22.5"
 
+"@babel/runtime@^7.1.2", "@babel/runtime@^7.21.0":
+  version "7.22.5"
+  resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.5.tgz#8564dd588182ce0047d55d7a75e93921107b57ec"
+  integrity sha512-ecjvYlnAaZ/KVneE/OdKYBYfgXV3Ptu6zQWmgEF7vwKhQnvVS6bjMD2XYgj+SNvQ1GfK/pjgokfPkC/2CO8CuA==
+  dependencies:
+    regenerator-runtime "^0.13.11"
+
 "@babel/runtime@^7.15.4", "@babel/runtime@^7.9.2":
   version "7.16.0"
   resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.0.tgz#e27b977f2e2088ba24748bf99b5e1dece64e4f0b"
   integrity sha512-Nht8L0O8YCktmsDV6FqFue7vQLRx3Hb0B37lS5y0jDRqRxlBG4wIJHnf9/bgSE2UyipKFA01YtS+npRdTWBUyw==
   dependencies:
     regenerator-runtime "^0.13.4"
-
-"@babel/runtime@^7.21.0":
-  version "7.22.5"
-  resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.5.tgz#8564dd588182ce0047d55d7a75e93921107b57ec"
-  integrity sha512-ecjvYlnAaZ/KVneE/OdKYBYfgXV3Ptu6zQWmgEF7vwKhQnvVS6bjMD2XYgj+SNvQ1GfK/pjgokfPkC/2CO8CuA==
-  dependencies:
-    regenerator-runtime "^0.13.11"
 
 "@babel/template@^7.18.6", "@babel/template@^7.22.5":
   version "7.22.5"
@@ -1092,6 +1092,11 @@
   resolved "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.0.tgz#9140779736aa2655635ee756e2467d787cfe8a2a"
   integrity sha512-c3Xy026kOF7QOTn00hbIllV1dLR9hG9NkSrLQgCVs8NF6sBU+VGWjD3wLPhmh1TYAc7ugCFsvHYMN4VcBN1U1A==
 
+"@types/js-cookie@^2.2.6":
+  version "2.2.7"
+  resolved "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-2.2.7.tgz#226a9e31680835a6188e887f3988e60c04d3f6a3"
+  integrity sha512-aLkWa0C0vO5b4Sr798E26QgOkss68Un0bLjs7u9qxzPT5CG+8DuNTffWES58YzJs3hrVAOs1wonycqEBqNJubA==
+
 "@types/json-schema@*", "@types/json-schema@^7.0.8", "@types/json-schema@^7.0.9":
   version "7.0.9"
   resolved "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz#97edc9037ea0c38585320b28964dde3b39e4660d"
@@ -1467,6 +1472,11 @@
   version "2.0.5"
   resolved "https://registry.npmjs.org/@webpack-cli/serve/-/serve-2.0.5.tgz#325db42395cd49fe6c14057f9a900e427df8810e"
   integrity sha512-lqaoKnRYBdo1UgDX8uF24AfGMifWK19TxPmM5FHc2vAGxrJ/qtyUyFBWoY1tISZdelsQ5fBcOusifo5o5wSJxQ==
+
+"@xobotyi/scrollbar-width@^1.9.5":
+  version "1.9.5"
+  resolved "https://registry.npmjs.org/@xobotyi/scrollbar-width/-/scrollbar-width-1.9.5.tgz#80224a6919272f405b87913ca13b92929bdf3c4d"
+  integrity sha512-N8tkAACJx2ww8vFMneJmaAgmjAG1tnVBZJRLRcx061tmsLRZHSEZSLuGWnwPtunsSLvSqXQ2wfp7Mgqg1I+2dQ==
 
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
@@ -2484,6 +2494,13 @@ convert-to-spaces@^2.0.1:
   resolved "https://registry.npmjs.org/convert-to-spaces/-/convert-to-spaces-2.0.1.tgz#61a6c98f8aa626c16b296b862a91412a33bceb6b"
   integrity sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ==
 
+copy-to-clipboard@^3.3.1:
+  version "3.3.3"
+  resolved "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.3.tgz#55ac43a1db8ae639a4bd99511c148cdd1b83a1b0"
+  integrity sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==
+  dependencies:
+    toggle-selection "^1.0.6"
+
 copy-webpack-plugin@11.0.0:
   version "11.0.0"
   resolved "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-11.0.0.tgz#96d4dbdb5f73d02dd72d0528d1958721ab72e04a"
@@ -2571,6 +2588,13 @@ cross-spawn@^7.0.0, cross-spawn@^7.0.1, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
+css-in-js-utils@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.npmjs.org/css-in-js-utils/-/css-in-js-utils-3.1.0.tgz#640ae6a33646d401fc720c54fc61c42cd76ae2bb"
+  integrity sha512-fJAcud6B3rRu+KHYk+Bwf+WFL2MDCJJ1XG9x137tJQ0xYxor7XziQtuGFbWNdqrvF4Tk26O3H73nfVqXt/fW1A==
+  dependencies:
+    hyphenate-style-name "^1.0.3"
+
 css-loader@6.8.1:
   version "6.8.1"
   resolved "https://registry.npmjs.org/css-loader/-/css-loader-6.8.1.tgz#0f8f52699f60f5e679eab4ec0fcd68b8e8a50a88"
@@ -2585,6 +2609,14 @@ css-loader@6.8.1:
     postcss-value-parser "^4.2.0"
     semver "^7.3.8"
 
+css-tree@^1.1.2:
+  version "1.1.3"
+  resolved "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz#eb4870fb6fd7707327ec95c2ff2ab09b5e8db91d"
+  integrity sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==
+  dependencies:
+    mdn-data "2.0.14"
+    source-map "^0.6.1"
+
 cssesc@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz#37741919903b868565e1c09ea747445cd18983ee"
@@ -2594,6 +2626,11 @@ csstype@^3.0.2:
   version "3.0.5"
   resolved "https://registry.npmjs.org/csstype/-/csstype-3.0.5.tgz#7fdec6a28a67ae18647c51668a9ff95bb2fa7bb8"
   integrity sha512-uVDi8LpBUKQj6sdxNaTetL6FpeCqTjOvAQuQUa/qAqq8oOd4ivkbhgnqayl0dnPal8Tb/yB1tF+gOvCBiicaiQ==
+
+csstype@^3.0.6:
+  version "3.1.2"
+  resolved "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz#1d4bf9d572f11c14031f0436e1c10bc1f571f50b"
+  integrity sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==
 
 currently-unhandled@^0.4.1:
   version "0.4.1"
@@ -3008,6 +3045,13 @@ error-ex@^1.3.1:
   integrity sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==
   dependencies:
     is-arrayish "^0.2.1"
+
+error-stack-parser@^2.0.6:
+  version "2.1.4"
+  resolved "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.1.4.tgz#229cb01cdbfa84440bfa91876285b94680188286"
+  integrity sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==
+  dependencies:
+    stackframe "^1.3.4"
 
 es-abstract@^1.19.0:
   version "1.19.1"
@@ -3432,10 +3476,25 @@ fast-levenshtein@^2.0.6:
   resolved "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
+fast-loops@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.npmjs.org/fast-loops/-/fast-loops-1.1.3.tgz#ce96adb86d07e7bf9b4822ab9c6fac9964981f75"
+  integrity sha512-8EZzEP0eKkEEVX+drtd9mtuQ+/QrlfW/5MlwcwK5Nds6EkZ/tRzEexkzUY2mIssnAyVLT+TKHuRXmFNNXYUd6g==
+
+fast-shallow-equal@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/fast-shallow-equal/-/fast-shallow-equal-1.0.0.tgz#d4dcaf6472440dcefa6f88b98e3251e27f25628b"
+  integrity sha512-HPtaa38cPgWvaCFmRNhlc6NG7pv6NUHqjPgVAkWGoB9mQMwYB27/K0CvOM5Czy+qpT3e8XJ6Q4aPAnzpNpzNaw==
+
 fastest-levenshtein@^1.0.12:
   version "1.0.12"
   resolved "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz#9990f7d3a88cc5a9ffd1f1745745251700d497e2"
   integrity sha512-On2N+BpYJ15xIC974QNVuYGMOlEVt4s0EOI3wwMqOmK1fdDY+FN/zltPV8vosq4ad4c/gJ1KHScUn/6AWIgiow==
+
+fastest-stable-stringify@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.npmjs.org/fastest-stable-stringify/-/fastest-stable-stringify-2.0.2.tgz#3757a6774f6ec8de40c4e86ec28ea02417214c76"
+  integrity sha512-bijHueCGd0LqqNK9b5oCMHc0MluJAx0cwqASgbWMvkO01lCYgIhacVRLcaDz3QnyYIRNJRDwMb41VuT6pHJ91Q==
 
 fastq@^1.6.0:
   version "1.10.0"
@@ -4079,6 +4138,11 @@ husky@8.0.3:
   resolved "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz#4936d7212e46d1dea28fef29bb3a108872cd9184"
   integrity sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==
 
+hyphenate-style-name@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz#691879af8e220aea5750e8827db4ef62a54e361d"
+  integrity sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ==
+
 iconv-corefoundation@^1.1.7:
   version "1.1.7"
   resolved "https://registry.npmjs.org/iconv-corefoundation/-/iconv-corefoundation-1.1.7.tgz#31065e6ab2c9272154c8b0821151e2c88f1b002a"
@@ -4196,6 +4260,14 @@ ini@~1.3.0:
   version "1.3.7"
   resolved "https://registry.npmjs.org/ini/-/ini-1.3.7.tgz#a09363e1911972ea16d7a8851005d84cf09a9a84"
   integrity sha512-iKpRpXP+CrP2jyrxvg1kMUpXDyRUFDWurxbnVT1vQPx+Wz9uCYsMIqYuSBLV+PAaZG/d7kRLKRFc9oDMsH+mFQ==
+
+inline-style-prefixer@^6.0.0:
+  version "6.0.4"
+  resolved "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-6.0.4.tgz#4290ed453ab0e4441583284ad86e41ad88384f44"
+  integrity sha512-FwXmZC2zbeeS7NzGjJ6pAiqRhXR0ugUShSNb6GApMl6da0/XGc4MOJsoWAywia52EEWbXNSy0pzkwz/+Y+swSg==
+  dependencies:
+    css-in-js-utils "^3.1.0"
+    fast-loops "^1.1.3"
 
 inquirer@9.2.7:
   version "9.2.7"
@@ -4577,6 +4649,11 @@ jest-worker@^27.4.5:
     "@types/node" "*"
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
+
+js-cookie@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz#69e106dc5d5806894562902aa5baec3744e9b2b8"
+  integrity sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==
 
 js-string-escape@^1.0.1:
   version "1.0.1"
@@ -5013,6 +5090,11 @@ md5-hex@^3.0.1:
   dependencies:
     blueimp-md5 "^2.10.0"
 
+mdn-data@2.0.14:
+  version "2.0.14"
+  resolved "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz#7113fc4281917d63ce29b43446f701e68c25ba50"
+  integrity sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==
+
 mem@^9.0.2:
   version "9.0.2"
   resolved "https://registry.npmjs.org/mem/-/mem-9.0.2.tgz#bbc2d40be045afe30749681e8f5d554cee0c0354"
@@ -5260,6 +5342,20 @@ mute-stream@1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz#e31bd9fe62f0aed23520aa4324ea6671531e013e"
   integrity sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==
+
+nano-css@^5.3.1:
+  version "5.3.5"
+  resolved "https://registry.npmjs.org/nano-css/-/nano-css-5.3.5.tgz#3075ea29ffdeb0c7cb6d25edb21d8f7fa8e8fe8e"
+  integrity sha512-vSB9X12bbNu4ALBu7nigJgRViZ6ja3OU7CeuiV1zMIbXOdmkLahgtPmh3GBOlDxbKY0CitqlPdOReGlBLSp+yg==
+  dependencies:
+    css-tree "^1.1.2"
+    csstype "^3.0.6"
+    fastest-stable-stringify "^2.0.2"
+    inline-style-prefixer "^6.0.0"
+    rtl-css-js "^1.14.0"
+    sourcemap-codec "^1.4.8"
+    stacktrace-js "^2.0.2"
+    stylis "^4.0.6"
 
 nanoid@^3.3.6:
   version "3.3.6"
@@ -6074,6 +6170,31 @@ react-redux@7.2.8:
     prop-types "^15.7.2"
     react-is "^17.0.2"
 
+react-universal-interface@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.npmjs.org/react-universal-interface/-/react-universal-interface-0.6.2.tgz#5e8d438a01729a4dbbcbeeceb0b86be146fe2b3b"
+  integrity sha512-dg8yXdcQmvgR13RIlZbTRQOoUrDciFVoSBZILwjE2LFISxZZ8loVJKAkuzswl5js8BHda79bIb2b84ehU8IjXw==
+
+react-use@^17.4.0:
+  version "17.4.0"
+  resolved "https://registry.npmjs.org/react-use/-/react-use-17.4.0.tgz#cefef258b0a6c534a5c8021c2528ac6e1a4cdc6d"
+  integrity sha512-TgbNTCA33Wl7xzIJegn1HndB4qTS9u03QUwyNycUnXaweZkE4Kq2SB+Yoxx8qbshkZGYBDvUXbXWRUmQDcZZ/Q==
+  dependencies:
+    "@types/js-cookie" "^2.2.6"
+    "@xobotyi/scrollbar-width" "^1.9.5"
+    copy-to-clipboard "^3.3.1"
+    fast-deep-equal "^3.1.3"
+    fast-shallow-equal "^1.0.0"
+    js-cookie "^2.2.1"
+    nano-css "^5.3.1"
+    react-universal-interface "^0.6.2"
+    resize-observer-polyfill "^1.5.1"
+    screenfull "^5.1.0"
+    set-harmonic-interval "^1.0.1"
+    throttle-debounce "^3.0.1"
+    ts-easing "^0.2.0"
+    tslib "^2.1.0"
+
 react@17.0.2:
   version "17.0.2"
   resolved "https://registry.npmjs.org/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
@@ -6245,6 +6366,11 @@ reselect@4.1.8:
   resolved "https://registry.npmjs.org/reselect/-/reselect-4.1.8.tgz#3f5dc671ea168dccdeb3e141236f69f02eaec524"
   integrity sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ==
 
+resize-observer-polyfill@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz#0e9020dd3d21024458d4ebd27e23e40269810464"
+  integrity sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==
+
 resolve-alpn@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.0.0.tgz#745ad60b3d6aff4b4a48e01b8c0bdc70959e0e8c"
@@ -6348,6 +6474,13 @@ roarr@^2.15.3:
     semver-compare "^1.0.0"
     sprintf-js "^1.1.2"
 
+rtl-css-js@^1.14.0:
+  version "1.16.1"
+  resolved "https://registry.npmjs.org/rtl-css-js/-/rtl-css-js-1.16.1.tgz#4b48b4354b0ff917a30488d95100fbf7219a3e80"
+  integrity sha512-lRQgou1mu19e+Ya0LsTvKrVJ5TYUbqCVPAiImX3UfLTenarvPUl1QFdvu5Z3PYmHT9RCcwIfbjRQBntExyj3Zg==
+  dependencies:
+    "@babel/runtime" "^7.1.2"
+
 run-async@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/run-async/-/run-async-3.0.0.tgz#42a432f6d76c689522058984384df28be379daad"
@@ -6438,6 +6571,11 @@ schema-utils@^4.0.0:
     ajv-formats "^2.1.1"
     ajv-keywords "^5.0.0"
 
+screenfull@^5.1.0:
+  version "5.2.0"
+  resolved "https://registry.npmjs.org/screenfull/-/screenfull-5.2.0.tgz#6533d524d30621fc1283b9692146f3f13a93d1ba"
+  integrity sha512-9BakfsO2aUQN2K9Fdbj87RJIEZ82Q9IGim7FqM5OsebfoFC6ZHXgDq/KvniuLTPdeM8wY2o6Dj3WQ7KeQCj3cA==
+
 seamless-immutable@7.1.4:
   version "7.1.4"
   resolved "https://registry.npmjs.org/seamless-immutable/-/seamless-immutable-7.1.4.tgz#6e9536def083ddc4dea0207d722e0e80d0f372f8"
@@ -6495,6 +6633,11 @@ set-blocking@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
+
+set-harmonic-interval@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/set-harmonic-interval/-/set-harmonic-interval-1.0.1.tgz#e1773705539cdfb80ce1c3d99e7f298bb3995249"
+  integrity sha512-AhICkFV84tBP1aWqPwLZqFvAwqEoVA9kxNMniGEUvzOlm4vLmOFLiTT3UZ6bziJTy4bOVpzWGTfSCbmaayGx8g==
 
 setimmediate@^1.0.5:
   version "1.0.5"
@@ -6640,12 +6783,17 @@ source-map-support@^0.5.19, source-map-support@~0.5.20:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
 
+source-map@0.5.6:
+  version "0.5.6"
+  resolved "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
+  integrity sha512-MjZkVp0NHr5+TPihLcadqnlVoGIoWo4IBHptutGh9wI3ttUYvCG26HkSuDi+K6lsZ25syXJXcctwgyVCt//xqA==
+
 source-map@^0.5.0:
   version "0.5.7"
   resolved "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
 
-source-map@^0.6.0, source-map@~0.6.1:
+source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
@@ -6654,6 +6802,11 @@ source-map@^0.7.3:
   version "0.7.3"
   resolved "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
+
+sourcemap-codec@^1.4.8:
+  version "1.4.8"
+  resolved "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz#ea804bd94857402e6992d05a38ef1ae35a9ab4c4"
+  integrity sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==
 
 spawn-command@0.0.2:
   version "0.0.2"
@@ -6703,12 +6856,41 @@ ssri@^10.0.0:
   dependencies:
     minipass "^5.0.0"
 
+stack-generator@^2.0.5:
+  version "2.0.10"
+  resolved "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.10.tgz#8ae171e985ed62287d4f1ed55a1633b3fb53bb4d"
+  integrity sha512-mwnua/hkqM6pF4k8SnmZ2zfETsRUpWXREfA/goT8SLCV4iOFa4bzOX2nDipWAZFPTjLvQB82f5yaodMVhK0yJQ==
+  dependencies:
+    stackframe "^1.3.4"
+
 stack-utils@^2.0.6:
   version "2.0.6"
   resolved "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz#aaf0748169c02fc33c8232abccf933f54a1cc34f"
   integrity sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==
   dependencies:
     escape-string-regexp "^2.0.0"
+
+stackframe@^1.3.4:
+  version "1.3.4"
+  resolved "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz#b881a004c8c149a5e8efef37d51b16e412943310"
+  integrity sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==
+
+stacktrace-gps@^3.0.4:
+  version "3.1.2"
+  resolved "https://registry.npmjs.org/stacktrace-gps/-/stacktrace-gps-3.1.2.tgz#0c40b24a9b119b20da4525c398795338966a2fb0"
+  integrity sha512-GcUgbO4Jsqqg6RxfyTHFiPxdPqF+3LFmQhm7MgCuYQOYuWyqxo5pwRPz5d/u6/WYJdEnWfK4r+jGbyD8TSggXQ==
+  dependencies:
+    source-map "0.5.6"
+    stackframe "^1.3.4"
+
+stacktrace-js@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.npmjs.org/stacktrace-js/-/stacktrace-js-2.0.2.tgz#4ca93ea9f494752d55709a081d400fdaebee897b"
+  integrity sha512-Je5vBeY4S1r/RnLydLl0TBTi3F2qdfWmYsGvtfZgEI+SCprPppaIhQf5nGcal4gI4cGpCV/duLcAzT1np6sQqg==
+  dependencies:
+    error-stack-parser "^2.0.6"
+    stack-generator "^2.0.5"
+    stacktrace-gps "^3.0.4"
 
 stat-mode@^1.0.0:
   version "1.0.0"
@@ -6853,6 +7035,11 @@ stylis@3.5.4:
   resolved "https://registry.npmjs.org/stylis/-/stylis-3.5.4.tgz#f665f25f5e299cf3d64654ab949a57c768b73fbe"
   integrity sha512-8/3pSmthWM7lsPBKv7NXkzn2Uc9W7NotcwGNpJaa3k7WMM1XDCA4MgT5k/8BIexd5ydZdboXtU90XH9Ec4Bv/Q==
 
+stylis@^4.0.6:
+  version "4.3.0"
+  resolved "https://registry.npmjs.org/stylis/-/stylis-4.3.0.tgz#abe305a669fc3d8777e10eefcfc73ad861c5588c"
+  integrity sha512-E87pIogpwUsUwXw7dNyU4QDjdgVMy52m+XEOPEKUn161cCzWjjhPSQhByfd1CcNvrOLnXQ6OnnZDwnJrz/Z4YQ==
+
 sumchecker@^3.0.1:
   version "3.0.1"
   resolved "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz#6377e996795abb0b6d348e9b3e1dfb24345a8e42"
@@ -6991,6 +7178,11 @@ text-table@^0.2.0:
   resolved "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
 
+throttle-debounce@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-3.0.1.tgz#32f94d84dfa894f786c9a1f290e7a645b6a19abb"
+  integrity sha512-dTEWWNu6JmeVXY0ZYoPuH5cRIwc0MeGbJwah9KUNYSJwommQpCzTySTpEe8Gs1J23aeWEuAobe4Ag7EHVt/LOg==
+
 through@^2.3.6:
   version "2.3.8"
   resolved "https://registry.npmjs.org/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
@@ -7047,6 +7239,11 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
+toggle-selection@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz#6e45b1263f2017fa0acc7d89d78b15b8bf77da32"
+  integrity sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ==
+
 toml-eslint-parser@^0.6.0:
   version "0.6.0"
   resolved "https://registry.npmjs.org/toml-eslint-parser/-/toml-eslint-parser-0.6.0.tgz#aaf394f2efd94d84d881113479d57d7597dc5d47"
@@ -7070,6 +7267,11 @@ truncate-utf8-bytes@^1.0.0:
   integrity sha1-QFkjkJWS1W94pYGENLC3hInKXys=
   dependencies:
     utf8-byte-length "^1.0.1"
+
+ts-easing@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.npmjs.org/ts-easing/-/ts-easing-0.2.0.tgz#c8a8a35025105566588d87dbda05dd7fbfa5a4ec"
+  integrity sha512-Z86EW+fFFh/IFB1fqQ3/+7Zpf9t2ebOAxNI/V6Wo7r5gqiqtxmgTlQ1qbqQcjLKYeSHPTsEmvlJUDg/EuL0uHQ==
 
 ts-node@10.9.1, ts-node@^10.9.1:
   version "10.9.1"


### PR DESCRIPTION
Adds support for defining multiple profiles and a new tab dropdown
Right now, it supports defining different `shell`, `shellArgs`, `env` and `workingDirectory` across profiles.

E.g.
<img width="1254" alt="Screenshot 2023-06-29 at 11 21 42" src="https://github.com/vercel/hyper/assets/16598275/3bf37f84-ffad-4dd5-a23e-c322ed9fc4e3">

Fun fact - you can use `/usr/bin/ssh` as shell too.

I have not added keyboard shortcuts yet, will have to think more about that. Right now the only way to open a different profile is to go through the new tab dropdown, once opened splits and new tabs should follow current focused pane's profile.

UI config options for profiles to come later.

Fixes #1147 
Fixes #3436 
Fixes #6448 