### PR TITLE
patch node-pty on windows

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -9,6 +9,9 @@
     "email": "team@zeit.co"
   },
   "repository": "zeit/hyper",
+  "scripts": {
+    "postinstall": "npx patch-package"
+  },
   "dependencies": {
     "@babel/parser": "7.22.5",
     "@electron/remote": "2.0.10",

--- a/app/patches/node-pty+1.0.0.patch
+++ b/app/patches/node-pty+1.0.0.patch
@@ -1,0 +1,15 @@
+diff --git a/node_modules/node-pty/src/win/conpty.cc b/node_modules/node-pty/src/win/conpty.cc
+index 47af75c..884d542 100644
+--- a/node_modules/node-pty/src/win/conpty.cc
++++ b/node_modules/node-pty/src/win/conpty.cc
+@@ -472,10 +472,6 @@ static NAN_METHOD(PtyKill) {
+       }
+     }
+ 
+-    DisconnectNamedPipe(handle->hIn);
+-    DisconnectNamedPipe(handle->hOut);
+-    CloseHandle(handle->hIn);
+-    CloseHandle(handle->hOut);
+     CloseHandle(handle->hShell);
+   }
+ 

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -57,6 +57,10 @@ const config: webpack.Configuration[] = [
           {
             from: './app/static',
             to: './static'
+          },
+          {
+            from: './app/patches',
+            to: './patches'
           }
         ]
       })


### PR DESCRIPTION
patch node-pty on windows to silence the EPIPE errors happening on closing tabs with `useConpty: true`
Can be removed when https://github.com/microsoft/node-pty/issues/512 is closed.
Better to patch for now rather than using an older version for upcoming canary release.