### PR TITLE
Add Shell Menu and Context Menu Support for Opening Windows with Specific Profiles

### DIFF
--- a/app/commands.ts
+++ b/app/commands.ts
@@ -147,6 +147,9 @@ const commands: Record<string, (focusedWindow?: BrowserWindow) => void> = {
 
 //Profile specific commands
 getConfig().profiles.forEach((profile) => {
+  commands[`window:new:${profile.name}`] = () => {
+    setTimeout(() => app.createWindow(undefined, undefined, profile.name), 0);
+  };
   commands[`tab:new:${profile.name}`] = (focusedWindow) => {
     focusedWindow?.rpc.emit('termgroup add req', {profile: profile.name});
   };

--- a/app/config/schema.json
+++ b/app/config/schema.json
@@ -27,12 +27,217 @@
         },
         "Partial<profileConfigOptions>": {
             "properties": {
+                "backgroundColor": {
+                    "description": "terminal background color\n\nopacity is only supported on macOS",
+                    "type": "string"
+                },
+                "bell": {
+                    "description": "Supported Options:\n1. 'SOUND' -> Enables the bell as a sound\n2. false: turns off the bell",
+                    "type": "string"
+                },
+                "bellSound": {
+                    "description": "base64 encoded string of the sound file to use for the bell\nif null, the default bell will be used",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "bellSoundURL": {
+                    "description": "An absolute file path to a sound file on the machine.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "borderColor": {
+                    "description": "border color (window, tabs)",
+                    "type": "string"
+                },
+                "colors": {
+                    "description": "the full list. if you're going to provide the full color palette,\nincluding the 6 x 6 color cubes and the grayscale map, just provide\nan array here instead of a color map object",
+                    "properties": {
+                        "black": {
+                            "type": "string"
+                        },
+                        "blue": {
+                            "type": "string"
+                        },
+                        "cyan": {
+                            "type": "string"
+                        },
+                        "green": {
+                            "type": "string"
+                        },
+                        "lightBlack": {
+                            "type": "string"
+                        },
+                        "lightBlue": {
+                            "type": "string"
+                        },
+                        "lightCyan": {
+                            "type": "string"
+                        },
+                        "lightGreen": {
+                            "type": "string"
+                        },
+                        "lightMagenta": {
+                            "type": "string"
+                        },
+                        "lightRed": {
+                            "type": "string"
+                        },
+                        "lightWhite": {
+                            "type": "string"
+                        },
+                        "lightYellow": {
+                            "type": "string"
+                        },
+                        "magenta": {
+                            "type": "string"
+                        },
+                        "red": {
+                            "type": "string"
+                        },
+                        "white": {
+                            "type": "string"
+                        },
+                        "yellow": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "black",
+                        "blue",
+                        "cyan",
+                        "green",
+                        "lightBlack",
+                        "lightBlue",
+                        "lightCyan",
+                        "lightGreen",
+                        "lightMagenta",
+                        "lightRed",
+                        "lightWhite",
+                        "lightYellow",
+                        "magenta",
+                        "red",
+                        "white",
+                        "yellow"
+                    ],
+                    "type": "object"
+                },
+                "copyOnSelect": {
+                    "description": "if `true` selected text will automatically be copied to the clipboard",
+                    "type": "boolean"
+                },
+                "css": {
+                    "description": "custom CSS to embed in the main window",
+                    "type": "string"
+                },
+                "cursorAccentColor": {
+                    "description": "terminal text color under BLOCK cursor",
+                    "type": "string"
+                },
+                "cursorBlink": {
+                    "description": "set to `true` for blinking cursor",
+                    "type": "boolean"
+                },
+                "cursorColor": {
+                    "description": "terminal cursor background color and opacity (hex, rgb, hsl, hsv, hwb or cmyk)",
+                    "type": "string"
+                },
+                "cursorShape": {
+                    "description": "`'BEAM'` for |, `'UNDERLINE'` for _, `'BLOCK'` for █",
+                    "enum": [
+                        "BEAM",
+                        "BLOCK",
+                        "UNDERLINE"
+                    ],
+                    "type": "string"
+                },
+                "disableLigatures": {
+                    "description": "if `false` Hyper will use ligatures provided by some fonts",
+                    "type": "boolean"
+                },
                 "env": {
                     "additionalProperties": {
                         "type": "string"
                     },
                     "description": "for environment variables",
                     "type": "object"
+                },
+                "fontFamily": {
+                    "description": "font family with optional fallbacks",
+                    "type": "string"
+                },
+                "fontSize": {
+                    "description": "default font size in pixels for all tabs",
+                    "type": "number"
+                },
+                "fontWeight": {
+                    "$ref": "#/definitions/FontWeight",
+                    "description": "default font weight eg:'normal', '400', 'bold'"
+                },
+                "fontWeightBold": {
+                    "$ref": "#/definitions/FontWeight",
+                    "description": "font weight for bold characters eg:'normal', '600', 'bold'"
+                },
+                "foregroundColor": {
+                    "description": "color of the text",
+                    "type": "string"
+                },
+                "imageSupport": {
+                    "description": "Whether to enable Sixel and iTerm2 inline image protocol support or not.",
+                    "type": "boolean"
+                },
+                "letterSpacing": {
+                    "description": "letter spacing as a relative unit",
+                    "type": "number"
+                },
+                "lineHeight": {
+                    "description": "line height as a relative unit",
+                    "type": "number"
+                },
+                "macOptionSelectionMode": {
+                    "description": "choose either `'vertical'`, if you want the column mode when Option key is hold during selection (Default)\nor `'force'`, if you want to force selection regardless of whether the terminal is in mouse events mode\n(inside tmux or vim with mouse mode enabled for example).",
+                    "type": "string"
+                },
+                "modifierKeys": {
+                    "properties": {
+                        "altIsMeta": {
+                            "type": "boolean"
+                        },
+                        "cmdIsMeta": {
+                            "type": "boolean"
+                        }
+                    },
+                    "required": [
+                        "altIsMeta",
+                        "cmdIsMeta"
+                    ],
+                    "type": "object"
+                },
+                "padding": {
+                    "description": "custom padding (CSS format, i.e.: `top right bottom left` or `top horizontal bottom` or `vertical horizontal` or `all`)",
+                    "type": "string"
+                },
+                "preserveCWD": {
+                    "description": "set to true to preserve working directory when creating splits or tabs",
+                    "type": "boolean"
+                },
+                "quickEdit": {
+                    "description": "if `true` on right click selected text will be copied or pasted if no\nselection is present (`true` by default on Windows and disables the context menu feature)",
+                    "type": "boolean"
+                },
+                "screenReaderMode": {
+                    "description": "set to true to enable screen reading apps (like NVDA) to read the contents of the terminal",
+                    "type": "boolean"
+                },
+                "scrollback": {
+                    "type": "number"
+                },
+                "selectionColor": {
+                    "description": "terminal selection color",
+                    "type": "string"
                 },
                 "shell": {
                     "description": "the shell to run when spawning a new session (e.g. /usr/local/bin/fish)\nif left empty, your system's login shell will be used by default\n\nWindows\n- Make sure to use a full path if the binary name doesn't work\n- Remove `--login` in shellArgs\n\nWindows Subsystem for Linux (WSL) - previously Bash on Windows\n- Example: `C:\\\\Windows\\\\System32\\\\wsl.exe`\n\nGit-bash on Windows\n- Example: `C:\\\\Program Files\\\\Git\\\\bin\\\\bash.exe`\n\nPowerShell on Windows\n- Example: `C:\\\\WINDOWS\\\\System32\\\\WindowsPowerShell\\\\v1.0\\\\powershell.exe`\n\nCygwin\n- Example: `C:\\\\cygwin64\\\\bin\\\\bash.exe`\n\nGit Bash\n- Example: `C:\\\\Program Files\\\\Git\\\\git-cmd.exe`\nThen Add `--command=usr/bin/bash.exe` to shellArgs",
@@ -43,6 +248,59 @@
                     "items": {
                         "type": "string"
                     },
+                    "type": "array"
+                },
+                "showHamburgerMenu": {
+                    "description": "if you're using a Linux setup which show native menus, set to false\n\ndefault: `true` on Linux, `true` on Windows, ignored on macOS",
+                    "enum": [
+                        "",
+                        false,
+                        true
+                    ]
+                },
+                "showWindowControls": {
+                    "description": "set to `false` if you want to hide the minimize, maximize and close buttons\n\nadditionally, set to `'left'` if you want them on the left, like in Ubuntu\n\ndefault: `true` on Windows and Linux, ignored on macOS",
+                    "enum": [
+                        "",
+                        false,
+                        "left",
+                        true
+                    ]
+                },
+                "termCSS": {
+                    "description": "custom CSS to embed in the terminal window",
+                    "type": "string"
+                },
+                "uiFontFamily": {
+                    "type": "string"
+                },
+                "webGLRenderer": {
+                    "description": "Whether to use the WebGL renderer. Set it to false to use canvas-based\nrendering (slower, but supports transparent backgrounds)",
+                    "type": "boolean"
+                },
+                "webLinksActivationKey": {
+                    "description": "keypress required for weblink activation: [ctrl | alt | meta | shift]",
+                    "enum": [
+                        "",
+                        "alt",
+                        "ctrl",
+                        "meta",
+                        "shift"
+                    ],
+                    "type": "string"
+                },
+                "windowSize": {
+                    "description": "Initial window size in pixels",
+                    "items": [
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "type": "number"
+                        }
+                    ],
+                    "maxItems": 2,
+                    "minItems": 2,
                     "type": "array"
                 },
                 "workingDirectory": {
@@ -63,6 +321,36 @@
                                 "boolean"
                             ]
                         },
+                        "defaultSSHApp": {
+                            "description": "if `true` hyper will be set as the default protocol client for SSH",
+                            "type": "boolean"
+                        },
+                        "disableAutoUpdates": {
+                            "description": "if `true` hyper will not check for updates",
+                            "type": "boolean"
+                        },
+                        "updateChannel": {
+                            "description": "choose either `'stable'` for receiving highly polished, or `'canary'` for less polished but more frequent updates",
+                            "enum": [
+                                "canary",
+                                "stable"
+                            ],
+                            "type": "string"
+                        },
+                        "useConpty": {
+                            "type": "boolean"
+                        }
+                    },
+                    "required": [
+                        "autoUpdatePlugins",
+                        "defaultSSHApp",
+                        "disableAutoUpdates",
+                        "updateChannel"
+                    ],
+                    "type": "object"
+                },
+                {
+                    "properties": {
                         "backgroundColor": {
                             "description": "terminal background color\n\nopacity is only supported on macOS",
                             "type": "string"
@@ -190,17 +478,16 @@
                             ],
                             "type": "string"
                         },
-                        "defaultSSHApp": {
-                            "description": "if `true` hyper will be set as the default protocol client for SSH",
-                            "type": "boolean"
-                        },
-                        "disableAutoUpdates": {
-                            "description": "if `true` hyper will not check for updates",
-                            "type": "boolean"
-                        },
                         "disableLigatures": {
                             "description": "if `false` Hyper will use ligatures provided by some fonts",
                             "type": "boolean"
+                        },
+                        "env": {
+                            "additionalProperties": {
+                                "type": "string"
+                            },
+                            "description": "for environment variables",
+                            "type": "object"
                         },
                         "fontFamily": {
                             "description": "font family with optional fallbacks",
@@ -276,6 +563,17 @@
                             "description": "terminal selection color",
                             "type": "string"
                         },
+                        "shell": {
+                            "description": "the shell to run when spawning a new session (e.g. /usr/local/bin/fish)\nif left empty, your system's login shell will be used by default\n\nWindows\n- Make sure to use a full path if the binary name doesn't work\n- Remove `--login` in shellArgs\n\nWindows Subsystem for Linux (WSL) - previously Bash on Windows\n- Example: `C:\\\\Windows\\\\System32\\\\wsl.exe`\n\nGit-bash on Windows\n- Example: `C:\\\\Program Files\\\\Git\\\\bin\\\\bash.exe`\n\nPowerShell on Windows\n- Example: `C:\\\\WINDOWS\\\\System32\\\\WindowsPowerShell\\\\v1.0\\\\powershell.exe`\n\nCygwin\n- Example: `C:\\\\cygwin64\\\\bin\\\\bash.exe`\n\nGit Bash\n- Example: `C:\\\\Program Files\\\\Git\\\\git-cmd.exe`\nThen Add `--command=usr/bin/bash.exe` to shellArgs",
+                            "type": "string"
+                        },
+                        "shellArgs": {
+                            "description": "for setting shell arguments (e.g. for using interactive shellArgs: `['-i']`)\nby default `['--login']` will be used",
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
                         "showHamburgerMenu": {
                             "description": "if you're using a Linux setup which show native menus, set to false\n\ndefault: `true` on Linux, `true` on Windows, ignored on macOS",
                             "enum": [
@@ -299,17 +597,6 @@
                         },
                         "uiFontFamily": {
                             "type": "string"
-                        },
-                        "updateChannel": {
-                            "description": "choose either `'stable'` for receiving highly polished, or `'canary'` for less polished but more frequent updates",
-                            "enum": [
-                                "canary",
-                                "stable"
-                            ],
-                            "type": "string"
-                        },
-                        "useConpty": {
-                            "type": "boolean"
                         },
                         "webGLRenderer": {
                             "description": "Whether to use the WebGL renderer. Set it to false to use canvas-based\nrendering (slower, but supports transparent backgrounds)",
@@ -339,10 +626,13 @@
                             "maxItems": 2,
                             "minItems": 2,
                             "type": "array"
+                        },
+                        "workingDirectory": {
+                            "description": "set custom startup directory (must be an absolute path)",
+                            "type": "string"
                         }
                     },
                     "required": [
-                        "autoUpdatePlugins",
                         "backgroundColor",
                         "bell",
                         "bellSound",
@@ -355,9 +645,8 @@
                         "cursorBlink",
                         "cursorColor",
                         "cursorShape",
-                        "defaultSSHApp",
-                        "disableAutoUpdates",
                         "disableLigatures",
+                        "env",
                         "fontFamily",
                         "fontSize",
                         "fontWeight",
@@ -373,44 +662,13 @@
                         "screenReaderMode",
                         "scrollback",
                         "selectionColor",
+                        "shell",
+                        "shellArgs",
                         "showHamburgerMenu",
                         "showWindowControls",
                         "termCSS",
-                        "updateChannel",
                         "webGLRenderer",
-                        "webLinksActivationKey"
-                    ],
-                    "type": "object"
-                },
-                {
-                    "properties": {
-                        "env": {
-                            "additionalProperties": {
-                                "type": "string"
-                            },
-                            "description": "for environment variables",
-                            "type": "object"
-                        },
-                        "shell": {
-                            "description": "the shell to run when spawning a new session (e.g. /usr/local/bin/fish)\nif left empty, your system's login shell will be used by default\n\nWindows\n- Make sure to use a full path if the binary name doesn't work\n- Remove `--login` in shellArgs\n\nWindows Subsystem for Linux (WSL) - previously Bash on Windows\n- Example: `C:\\\\Windows\\\\System32\\\\wsl.exe`\n\nGit-bash on Windows\n- Example: `C:\\\\Program Files\\\\Git\\\\bin\\\\bash.exe`\n\nPowerShell on Windows\n- Example: `C:\\\\WINDOWS\\\\System32\\\\WindowsPowerShell\\\\v1.0\\\\powershell.exe`\n\nCygwin\n- Example: `C:\\\\cygwin64\\\\bin\\\\bash.exe`\n\nGit Bash\n- Example: `C:\\\\Program Files\\\\Git\\\\git-cmd.exe`\nThen Add `--command=usr/bin/bash.exe` to shellArgs",
-                            "type": "string"
-                        },
-                        "shellArgs": {
-                            "description": "for setting shell arguments (e.g. for using interactive shellArgs: `['-i']`)\nby default `['--login']` will be used",
-                            "items": {
-                                "type": "string"
-                            },
-                            "type": "array"
-                        },
-                        "workingDirectory": {
-                            "description": "set custom startup directory (must be an absolute path)",
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "env",
-                        "shell",
-                        "shellArgs",
+                        "webLinksActivationKey",
                         "workingDirectory"
                     ],
                     "type": "object"

--- a/app/extend-electron.d.ts
+++ b/app/extend-electron.d.ts
@@ -10,7 +10,8 @@ declare global {
       windowCallback?: (win: BrowserWindow) => void;
       createWindow: (
         fn?: (win: BrowserWindow) => void,
-        options?: {size?: [number, number]; position?: [number, number]}
+        options?: {size?: [number, number]; position?: [number, number]},
+        profileName?: string
       ) => BrowserWindow;
       setVersion: (version: string) => void;
     }
@@ -22,6 +23,7 @@ declare global {
       focusTime: number;
       clean: () => void;
       rpc: Server;
+      profileName: string;
     }
   }
 }

--- a/app/index.ts
+++ b/app/index.ts
@@ -90,9 +90,10 @@ app.on('ready', () =>
     .then(() => {
       function createWindow(
         fn?: (win: BrowserWindow) => void,
-        options: {size?: [number, number]; position?: [number, number]} = {}
+        options: {size?: [number, number]; position?: [number, number]} = {},
+        profileName: string = config.getDefaultProfile()
       ) {
-        const cfg = plugins.getDecoratedConfig(config.getDefaultProfile());
+        const cfg = plugins.getDecoratedConfig(profileName);
 
         const winSet = config.getWin();
         let [startX, startY] = winSet.position;
@@ -134,7 +135,7 @@ app.on('ready', () =>
           [startX, startY] = config.windowDefaults.windowPosition;
         }
 
-        const hwin = newWindow({width, height, x: startX, y: startY}, cfg, fn);
+        const hwin = newWindow({width, height, x: startX, y: startY}, cfg, fn, profileName);
         windowSet.add(hwin);
         void hwin.loadURL(url);
 

--- a/app/menus/menus/shell.ts
+++ b/app/menus/menus/shell.ts
@@ -50,12 +50,14 @@ export default (
           submenu: [
             {
               label: 'New Tab',
+              accelerator: commandKeys[`tab:new:${profile}`],
               click(item, focusedWindow) {
                 execCommand(`tab:new:${profile}`, focusedWindow);
               }
             },
             {
               label: 'New Window',
+              accelerator: commandKeys[`window:new:${profile}`],
               click(item, focusedWindow) {
                 execCommand(`window:new:${profile}`, focusedWindow);
               }
@@ -65,12 +67,14 @@ export default (
             },
             {
               label: 'Split Down',
+              accelerator: commandKeys[`pane:splitDown:${profile}`],
               click(item, focusedWindow) {
                 execCommand(`pane:splitDown:${profile}`, focusedWindow);
               }
             },
             {
               label: 'Split Right',
+              accelerator: commandKeys[`pane:splitRight:${profile}`],
               click(item, focusedWindow) {
                 execCommand(`pane:splitRight:${profile}`, focusedWindow);
               }

--- a/app/menus/menus/shell.ts
+++ b/app/menus/menus/shell.ts
@@ -55,6 +55,12 @@ export default (
               }
             },
             {
+              label: 'New Window',
+              click(item, focusedWindow) {
+                execCommand(`window:new:${profile}`, focusedWindow);
+              }
+            },
+            {
               type: 'separator'
             },
             {

--- a/app/plugins.ts
+++ b/app/plugins.ts
@@ -425,10 +425,6 @@ export const getDecoratedEnv = (baseEnv: Record<string, string>) => {
   return decorateObject(baseEnv, 'decorateEnv');
 };
 
-export const getDefaultProfile = () => {
-  return config.getDefaultProfile();
-};
-
 export const getDecoratedConfig = (profile: string) => {
   const baseConfig = config.getProfileConfig(profile);
   const decoratedConfig = decorateObject(baseConfig, 'decorateConfig');

--- a/app/ui/window.ts
+++ b/app/ui/window.ts
@@ -25,7 +25,8 @@ import {getDefaultProfile} from '../config';
 export function newWindow(
   options_: BrowserWindowConstructorOptions,
   cfg: configOptions,
-  fn?: (win: BrowserWindow) => void
+  fn?: (win: BrowserWindow) => void,
+  profileName: string = getDefaultProfile()
 ): BrowserWindow {
   const classOpts = Object.assign({uid: uuidv4()});
   app.plugins.decorateWindowClass(classOpts);
@@ -51,6 +52,8 @@ export function newWindow(
   };
   const window = new BrowserWindow(app.plugins.getDecoratedBrowserOptions(winOpts));
 
+  window.profileName = profileName;
+
   // Enable remote module on this window
   remoteEnable(window.webContents);
 
@@ -63,13 +66,13 @@ export function newWindow(
   const sessions = new Map<string, Session>();
 
   const updateBackgroundColor = () => {
-    const cfg_ = app.plugins.getDecoratedConfig(getDefaultProfile());
+    const cfg_ = app.plugins.getDecoratedConfig(profileName);
     window.setBackgroundColor(toElectronBackgroundColor(cfg_.backgroundColor || '#000'));
   };
 
   // config changes
   const cfgUnsubscribe = app.config.subscribe(() => {
-    const cfg_ = app.plugins.getDecoratedConfig(getDefaultProfile());
+    const cfg_ = app.plugins.getDecoratedConfig(profileName);
 
     // notify renderer
     window.webContents.send('config change');
@@ -119,7 +122,7 @@ export function newWindow(
       if (extraOptions[key] !== undefined) extraOptionsFiltered[key] = extraOptions[key];
     });
 
-    const profile = extraOptionsFiltered.profile || getDefaultProfile();
+    const profile = extraOptionsFiltered.profile || profileName;
     const activeSession = extraOptionsFiltered.activeUid ? sessions.get(extraOptionsFiltered.activeUid) : undefined;
     let cwd = '';
     if (cfg.preserveCWD !== false && activeSession && activeSession.profile === profile) {
@@ -161,7 +164,7 @@ export function newWindow(
       },
       extraOptionsFiltered,
       {
-        profile: extraOptionsFiltered.profile || getDefaultProfile(),
+        profile: extraOptionsFiltered.profile || profileName,
         uid
       }
     );

--- a/lib/actions/term-groups.ts
+++ b/lib/actions/term-groups.ts
@@ -20,7 +20,7 @@ function requestSplit(direction: 'VERTICAL' | 'HORIZONTAL') {
         effect: () => {
           const {ui, sessions} = getState();
           const activeUid = _activeUid ? _activeUid : sessions.activeUid;
-          const profile = _profile ? _profile : activeUid ? sessions.sessions[activeUid].profile : undefined;
+          const profile = _profile ? _profile : activeUid ? sessions.sessions[activeUid].profile : window.profileName;
           rpc.emit('new', {
             splitDirection: direction,
             cwd: ui.cwd,
@@ -51,7 +51,7 @@ export function requestTermGroup(_activeUid: string | undefined, _profile: strin
         const {ui, sessions} = getState();
         const {cwd} = ui;
         const activeUid = _activeUid ? _activeUid : sessions.activeUid;
-        const profile = _profile ? _profile : activeUid ? sessions.sessions[activeUid].profile : undefined;
+        const profile = _profile ? _profile : activeUid ? sessions.sessions[activeUid].profile : window.profileName;
         rpc.emit('new', {
           isNewGroup: true,
           cwd,

--- a/lib/config.d.ts
+++ b/lib/config.d.ts
@@ -19,49 +19,22 @@ export type ColorMap = {
   yellow: string;
 };
 
-type profileConfigOptions = {
-  /** for environment variables */
-  env: {[k: string]: string};
-  /**
-   * the shell to run when spawning a new session (e.g. /usr/local/bin/fish)
-   * if left empty, your system's login shell will be used by default
-   *
-   * Windows
-   * - Make sure to use a full path if the binary name doesn't work
-   * - Remove `--login` in shellArgs
-   *
-   * Windows Subsystem for Linux (WSL) - previously Bash on Windows
-   * - Example: `C:\\Windows\\System32\\wsl.exe`
-   *
-   * Git-bash on Windows
-   * - Example: `C:\\Program Files\\Git\\bin\\bash.exe`
-   *
-   * PowerShell on Windows
-   * - Example: `C:\\WINDOWS\\System32\\WindowsPowerShell\\v1.0\\powershell.exe`
-   *
-   * Cygwin
-   * - Example: `C:\\cygwin64\\bin\\bash.exe`
-   *
-   * Git Bash
-   * - Example: `C:\\Program Files\\Git\\git-cmd.exe`
-   * Then Add `--command=usr/bin/bash.exe` to shellArgs
-   */
-  shell: string;
-  /**
-   * for setting shell arguments (e.g. for using interactive shellArgs: `['-i']`)
-   * by default `['--login']` will be used
-   */
-  shellArgs: string[];
-  /** set custom startup directory (must be an absolute path) */
-  workingDirectory: string;
-};
-
 type rootConfigOptions = {
   /**
    * if `true` (default), Hyper will update plugins every 5 hours
    * you can also set it to a custom time e.g. `1d` or `2h`
    */
   autoUpdatePlugins: boolean | string;
+  /** if `true` hyper will be set as the default protocol client for SSH */
+  defaultSSHApp: boolean;
+  /** if `true` hyper will not check for updates */
+  disableAutoUpdates: boolean;
+  /** choose either `'stable'` for receiving highly polished, or `'canary'` for less polished but more frequent updates */
+  updateChannel: 'stable' | 'canary';
+  useConpty?: boolean;
+};
+
+type profileConfigOptions = {
   /**
    * terminal background color
    *
@@ -105,12 +78,10 @@ type rootConfigOptions = {
   cursorColor: string;
   /** `'BEAM'` for |, `'UNDERLINE'` for _, `'BLOCK'` for █ */
   cursorShape: 'BEAM' | 'UNDERLINE' | 'BLOCK';
-  /** if `true` hyper will be set as the default protocol client for SSH */
-  defaultSSHApp: boolean;
-  /** if `true` hyper will not check for updates */
-  disableAutoUpdates: boolean;
   /** if `false` Hyper will use ligatures provided by some fonts */
   disableLigatures: boolean;
+  /** for environment variables */
+  env: {[k: string]: string};
   /** font family with optional fallbacks */
   fontFamily: string;
   /** default font size in pixels for all tabs */
@@ -158,6 +129,36 @@ type rootConfigOptions = {
   /** terminal selection color */
   selectionColor: string;
   /**
+   * the shell to run when spawning a new session (e.g. /usr/local/bin/fish)
+   * if left empty, your system's login shell will be used by default
+   *
+   * Windows
+   * - Make sure to use a full path if the binary name doesn't work
+   * - Remove `--login` in shellArgs
+   *
+   * Windows Subsystem for Linux (WSL) - previously Bash on Windows
+   * - Example: `C:\\Windows\\System32\\wsl.exe`
+   *
+   * Git-bash on Windows
+   * - Example: `C:\\Program Files\\Git\\bin\\bash.exe`
+   *
+   * PowerShell on Windows
+   * - Example: `C:\\WINDOWS\\System32\\WindowsPowerShell\\v1.0\\powershell.exe`
+   *
+   * Cygwin
+   * - Example: `C:\\cygwin64\\bin\\bash.exe`
+   *
+   * Git Bash
+   * - Example: `C:\\Program Files\\Git\\git-cmd.exe`
+   * Then Add `--command=usr/bin/bash.exe` to shellArgs
+   */
+  shell: string;
+  /**
+   * for setting shell arguments (e.g. for using interactive shellArgs: `['-i']`)
+   * by default `['--login']` will be used
+   */
+  shellArgs: string[];
+  /**
    * if you're using a Linux setup which show native menus, set to false
    *
    * default: `true` on Linux, `true` on Windows, ignored on macOS
@@ -174,9 +175,6 @@ type rootConfigOptions = {
   /** custom CSS to embed in the terminal window */
   termCSS: string;
   uiFontFamily?: string;
-  /** choose either `'stable'` for receiving highly polished, or `'canary'` for less polished but more frequent updates */
-  updateChannel: 'stable' | 'canary';
-  useConpty?: boolean;
   /**
    * Whether to use the WebGL renderer. Set it to false to use canvas-based
    * rendering (slower, but supports transparent backgrounds)
@@ -189,6 +187,8 @@ type rootConfigOptions = {
   webLinksActivationKey: 'ctrl' | 'alt' | 'meta' | 'shift' | '';
   /** Initial window size in pixels */
   windowSize?: [number, number];
+  /** set custom startup directory (must be an absolute path) */
+  workingDirectory: string;
 };
 
 export type configOptions = rootConfigOptions &

--- a/lib/hyper.d.ts
+++ b/lib/hyper.d.ts
@@ -6,6 +6,7 @@ declare global {
     __rpcId: string;
     rpc: Client;
     focusActiveTerm: (uid?: string) => void;
+    profileName: string;
   }
 
   const snapshotResult: {

--- a/lib/utils/config.ts
+++ b/lib/utils/config.ts
@@ -1,11 +1,20 @@
 import {ipcRenderer} from 'electron';
-import {require as remoteRequire} from '@electron/remote';
+import {require as remoteRequire, getCurrentWindow} from '@electron/remote';
 // TODO: Should be updates to new async API https://medium.com/@nornagon/electrons-remote-module-considered-harmful-70d69500f31
 
 const plugins = remoteRequire('./plugins') as typeof import('../../app/plugins');
 
+Object.defineProperty(window, 'profileName', {
+  get() {
+    return getCurrentWindow().profileName;
+  },
+  set() {
+    throw new Error('profileName is readonly');
+  }
+});
+
 export function getConfig() {
-  return plugins.getDecoratedConfig(plugins.getDefaultProfile());
+  return plugins.getDecoratedConfig(window.profileName);
 }
 
 export function subscribe(fn: (event: Electron.IpcRendererEvent, ...args: any[]) => void) {


### PR DESCRIPTION
Add the ability to open new windows with specific profiles through the shell menu and context menu.
UI related options can now be set per profile. All the options except `autoUpdatePlugins`, `defaultSSHApp`, `disableAutoUpdates`, `updateChannel` and `useConpty` can be set per profile.
Windows opened for a specific profile will follow the UI settings for that profile, one can open tabs and splits with different profiles but the UI, color scheme, terminal rendering etc. will follow the window's profile.

### Screenshots
<img width="1404" alt="Screenshot 2023-07-01 at 11 26 28" src="https://github.com/vercel/hyper/assets/16598275/e9d81a00-b85b-4fbe-9fe5-4757323427a0">
<img width="396" alt="Screenshot 2023-07-01 at 11 15 39" src="https://github.com/vercel/hyper/assets/16598275/b9ff46ef-b5ee-44c6-ab5a-fd77506483df">

