### PR TITLE
Implements dialog when closing terminal if process is running

### DIFF
--- a/app/utils/session-has-children.ts
+++ b/app/utils/session-has-children.ts
@@ -1,0 +1,28 @@
+import {readFileSync} from 'fs';
+import type Session from '../session';
+
+export default function sessionHasRunningChildren(session: Session): boolean {
+  if (process.platform == 'linux' && session.pty != null) {
+    try {
+      const childProcInfoPath = `/proc/${session.pty.pid}/task/${session.pty.pid}/children`;
+      return readFileSync(childProcInfoPath, 'utf8').length >= 1;
+    } catch (error) {
+      return false;
+    }
+  } else {
+    return false;
+  }
+}
+
+// export default function sessionHasRunningChildren(session: Session): boolean {
+//   if (process.platform == 'linux') {
+//     if (session.pty != null) {
+//       const childProcInfoPath = `/proc/${session.pty.pid}/task/${session.pty.pid}/children`;
+//       return readFileSync(childProcInfoPath, 'utf8').length >= 1;
+//     } else {
+//       return false;
+//     }
+//   } else {
+//     return false;
+//   }
+// }

--- a/app/utils/session-has-children.ts
+++ b/app/utils/session-has-children.ts
@@ -13,16 +13,3 @@ export default function sessionHasRunningChildren(session: Session): boolean {
     return false;
   }
 }
-
-// export default function sessionHasRunningChildren(session: Session): boolean {
-//   if (process.platform == 'linux') {
-//     if (session.pty != null) {
-//       const childProcInfoPath = `/proc/${session.pty.pid}/task/${session.pty.pid}/children`;
-//       return readFileSync(childProcInfoPath, 'utf8').length >= 1;
-//     } else {
-//       return false;
-//     }
-//   } else {
-//     return false;
-//   }
-// }

--- a/test/unit/window-utils.test.ts
+++ b/test/unit/window-utils.test.ts
@@ -1,6 +1,7 @@
 // eslint-disable-next-line eslint-comments/disable-enable-pair
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 import test from 'ava';
+import sessionHasRunningChildren from '../../app/utils/session-has-children';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const proxyquire = require('proxyquire').noCallThru();
 
@@ -88,4 +89,18 @@ test('positionIsValid() returns false when position isnt valid', (t) => {
   const result = windowUtils.positionIsValid(position);
 
   t.false(result);
+});
+
+test('Closing the terminal should show dialog', (t) => {
+  const shouldClose = sessionHasRunningChildren({pty: {pid: 1}});
+  t.true(shouldClose);
+});
+
+test('Has a invalid pid', (t) => {
+  t.false(sessionHasRunningChildren({pty: {pid: -99999}}));
+});
+
+test('Should not show dialog', (t) => {
+  const shouldClose = sessionHasRunningChildren({pty: null});
+  t.false(shouldClose);
 });


### PR DESCRIPTION
<!-- Hi there! Thanks for submitting a PR! We're excited to see what you've got for us.

- To help whoever reviews your PR, it'd be extremely helpful for you to list whether your PR is ready to be merged,
If there's anything left to do and if there are any related PRs
- It'd also be extremely helpful to enable us to update your PR incase we need to rebase or what-not by checking `Allow edits from maintainers`
- If your PR changes some API, please make a PR for hyper website too: https://github.com/vercel/hyper-site.

Thanks, again! -->

Hey, this PR contains the feature requested at #684 and 3 test cases for the method that detects if a process is running to handle the dialog call.

Also, is good to add more test cases and think of a framework to mock stuff along with Ava.

Closes #684 
