### PR TITLE
Support alternate certificate authorities

### DIFF
--- a/app/plugins/install.ts
+++ b/app/plugins/install.ts
@@ -9,6 +9,7 @@ export const install = (fn: (err: string | null) => void) => {
   const spawnQueue = queue({concurrency: 1});
   function yarnFn(args: string[], cb: (err: string | null) => void) {
     const env = {
+      ...process.env,
       NODE_ENV: 'production',
       ELECTRON_RUN_AS_NODE: 'true'
     };

--- a/cli/api.ts
+++ b/cli/api.ts
@@ -24,6 +24,16 @@ const fileName =
     ? devConfigFileName
     : path.join(applicationDirectory, 'hyper.json');
 
+const https = {
+  ...(
+    // Respect the NODE_EXTRA_CA_CERTS variable for environments that need alternate certificate
+    // authorities (SSL Inspection, etc.)
+    process.env.NODE_EXTRA_CA_CERTS && fs.existsSync(process.env.NODE_EXTRA_CA_CERTS)
+      ? { certificateAuthority: fs.readFileSync(process.env.NODE_EXTRA_CA_CERTS) }
+      : {}
+  )
+}
+
 /**
  * We need to make sure the file reading and parsing is lazy so that failure to
  * statically analyze the hyper configuration isn't fatal for all kinds of
@@ -87,7 +97,7 @@ function getPackageName(plugin: string) {
 function existsOnNpm(plugin: string) {
   const name = getPackageName(plugin);
   return got
-    .get<any>(registryUrl + name.toLowerCase(), {timeout: {request: 10000}, responseType: 'json'})
+    .get<any>(registryUrl + name.toLowerCase(), {timeout: {request: 10000}, https, responseType: 'json'})
     .then((res) => {
       if (!res.body.versions) {
         return Promise.reject(res);

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -19,6 +19,16 @@ import * as api from './api';
 
 let commandPromise: Promise<void> | undefined;
 
+const https = {
+  ...(
+    // Respect the NODE_EXTRA_CA_CERTS variable for environments that need alternate certificate
+    // authorities (SSL Inspection, etc.)
+    process.env.NODE_EXTRA_CA_CERTS && fs.existsSync(process.env.NODE_EXTRA_CA_CERTS)
+      ? { certificateAuthority: fs.readFileSync(process.env.NODE_EXTRA_CA_CERTS) }
+      : {}
+  )
+}
+
 const assertPluginName = (pluginName: string) => {
   if (!pluginName) {
     console.error(chalk.red('Plugin name is required'));
@@ -105,7 +115,7 @@ const lsRemote = (pattern?: string) => {
     (pattern && `${pattern}+`) || ''
   }keywords:hyper-plugin,hyper-theme&size=250`;
   type npmResult = {package: {name: string; description: string}};
-  return got(URL)
+  return got(URL, { https })
     .then((response) => JSON.parse(response.body).results as npmResult[])
     .then((entries) => entries.map((entry) => entry.package))
     .then((entries) =>


### PR DESCRIPTION
Respect the `NODE_EXTRA_CA_CERTS` environment variable and set alternate certificate authorities from the path it specifies if defined and the file exists. This makes network access compatible with npm and other tools that also respect this variable.

Also update the environment passed to yarn to include the existing environment with overwritten values. This should also let yarn see this variable and use it for its network access.

This is necessary in environments that use SSL interception, where all certs are replaced by a single cert chain that isn't and can't be valid (it's created on the fly). This is becoming increasingly common within corporate environments, and is critical to developers who work in these spaces (hyper is unusable without this change).