### PR TITLE
Fix documentation typos

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@
 
 - To help whoever reviews your PR, it'd be extremely helpful for you to list whether your PR is ready to be merged,
 If there's anything left to do and if there are any related PRs
-- It'd also be extremely helpful to enable us to update your PR incase we need to rebase or what-not by checking `Allow edits from maintainers`
+- It'd also be extremely helpful to enable us to update your PR in case we need to rebase or what-not by checking `Allow edits from maintainers`
 - If your PR changes some API, please make a PR for hyper website too: https://github.com/vercel/hyper-site.
 
 Thanks, again! -->

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -5,7 +5,7 @@
 ### Run Hyper in dev mode
 Hyper can be run in dev mode by cloning this repository and following the ["Contributing" section of our README](https://github.com/vercel/hyper#contribute).
 
-In dev mode you'll get more ouput and access to React/Redux dev-tools in Electron.
+In dev mode you'll get more output and access to React/Redux dev-tools in Electron.
 
 Prerequisites and steps are described in the ["Contributing" section of our README](https://github.com/vercel/hyper#contribute).
 Be sure to use the `canary` branch.
@@ -32,7 +32,7 @@ module.exports = {
 ### Running your plugin
 To load, your plugin should expose at least one API method. All possible methods are listed [here](https://github.com/vercel/hyper/blob/canary/app/plugins/extensions.ts).
 
-After launching Hyper in dev mode, run `pnpm run app`, it should log that your plugin has been correcty loaded: `Plugin hyper-awesome-plugin (0.1.0) loaded.`. Name and version printed are the ones in your plugins `package.json` file.
+After launching Hyper in dev mode, run `pnpm run app`, it should log that your plugin has been correctly loaded: `Plugin hyper-awesome-plugin (0.1.0) loaded.`. Name and version printed are the ones in your plugins `package.json` file.
 
 When you put a `console.log()` in your plugin code, it will be displayed in the Electron dev-tools, but only if it is located in a renderer method, like component decorators. If it is located in the Electron main process method, like the `onApp` handler, it will be displayed in your terminal where you ran `pnpm run app` or in your VSCode console.
 
@@ -152,7 +152,7 @@ exports.decorateMenu = (menu) => {
         label: 'Clear all panes in all tabs',
         accelerator: 'ctrl+shift+y',
         click(item, focusedWindow) {
-          // on macOS, menu item can clicked without or minized window
+          // on macOS, menu item can clicked without or minimized window
           if (focusedWindow) {
             focusedWindow.rpc.emit('clear allPanes');
           }


### PR DESCRIPTION
## Summary
I fix spelling mistakes in documentation and changelog text.

Changed files:
- `.github/pull_request_template.md`
- `PLUGINS.md`

## Testing
I run `git diff --check`.
