### PR TITLE
Hi! This PR fixes an issue where alpha values less than 1 (such as 0.05) would generate a single-character hex representation for the alpha channel (e.g., `d` instead of `0d`).   This resulted in an invalid 7-character hex string which broke background transparency when opening new windows or restarting the application.  I solved this by adding `.padStart(2, '0')` to the `alphaHex` generation in `to-electron-background-color.ts` to guarantee a valid 8-character hex output.  Closes #2847fix: pad single-character hex values in electron background color

### DIFF
--- a/app/utils/to-electron-background-color.ts
+++ b/app/utils/to-electron-background-color.ts
@@ -12,7 +12,7 @@ const toElectronBackgroundColor = (bgColor: string) => {
   }
 
   // http://stackoverflow.com/a/11019879/1202488
-  const alphaHex = Math.round(color.alpha() * 255).toString(16);
+  const alphaHex = Math.round(color.alpha() * 255).toString(16).padStart(2, '0');
   return `#${alphaHex}${color.hex().toString().slice(1)}`;
 };
 


### PR DESCRIPTION
<!-- Hi there! Thanks for submitting a PR! We're excited to see what you've got for us.

- To help whoever reviews your PR, it'd be extremely helpful for you to list whether your PR is ready to be merged,
If there's anything left to do and if there are any related PRs
- It'd also be extremely helpful to enable us to update your PR incase we need to rebase or what-not by checking `Allow edits from maintainers`
- If your PR changes some API, please make a PR for hyper website too: https://github.com/vercel/hyper-site.

Thanks, again! -->
