### PR TITLE
Paint body background on mount so new windows keep transparency

### DIFF
--- a/lib/containers/hyper.tsx
+++ b/lib/containers/hyper.tsx
@@ -27,14 +27,10 @@ const Hyper = forwardRef<HTMLDivElement, HyperProps>((props, ref) => {
     handleFocusActive(props.activeSession);
   }, [props.activeSession]);
   useEffect(() => {
-    // Electron ignores the BrowserWindow backgroundColor (and setBackgroundColor)
-    // alpha channel on transparent windows, so the translucent background must be
-    // painted by the renderer. Running on mount as well as on change fixes new
-    // windows opening without their configured transparency (#6531).
+    // Electron ignores the alpha channel of BrowserWindow backgroundColor on
+    // transparent windows, so the renderer must paint the translucent
+    // background — on mount too, or new windows lose transparency (#6531)
     document.body.style.backgroundColor = props.backgroundColor;
-    return () => {
-      document.body.style.backgroundColor = 'inherit';
-    };
   }, [props.backgroundColor]);
 
   const handleFocusActive = (uid?: string | null) => {

--- a/lib/containers/hyper.tsx
+++ b/lib/containers/hyper.tsx
@@ -26,6 +26,16 @@ const Hyper = forwardRef<HTMLDivElement, HyperProps>((props, ref) => {
   useEffect(() => {
     handleFocusActive(props.activeSession);
   }, [props.activeSession]);
+  useEffect(() => {
+    // Electron ignores the BrowserWindow backgroundColor (and setBackgroundColor)
+    // alpha channel on transparent windows, so the translucent background must be
+    // painted by the renderer. Running on mount as well as on change fixes new
+    // windows opening without their configured transparency (#6531).
+    document.body.style.backgroundColor = props.backgroundColor;
+    return () => {
+      document.body.style.backgroundColor = 'inherit';
+    };
+  }, [props.backgroundColor]);
 
   const handleFocusActive = (uid?: string | null) => {
     const term = uid && terms.current?.getTermByUid(uid);

--- a/lib/containers/hyper.tsx
+++ b/lib/containers/hyper.tsx
@@ -27,9 +27,7 @@ const Hyper = forwardRef<HTMLDivElement, HyperProps>((props, ref) => {
     handleFocusActive(props.activeSession);
   }, [props.activeSession]);
   useEffect(() => {
-    // Electron ignores the alpha channel of BrowserWindow backgroundColor on
-    // transparent windows, so the renderer must paint the translucent
-    // background — on mount too, or new windows lose transparency (#6531)
+    // Electron drops the alpha of BrowserWindow backgroundColor, so paint it here — on mount too (#6531)
     document.body.style.backgroundColor = props.backgroundColor;
   }, [props.backgroundColor]);
 


### PR DESCRIPTION
Fixes #6531.

New windows open without their configured background transparency (macOS, `backgroundColor` with alpha < 1). The tint only appears after the config file is touched or the window is resized.

**Root cause.** Electron ignores the alpha channel of `BrowserWindow` `backgroundColor`/`setBackgroundColor` on `transparent: true` windows, so the translucent background has to be painted by the renderer. The old fallback in `Hyper`'s `componentDidUpdate` (removed in #7299) only painted `document.body` when `backgroundColor` *changed* between renders — but `CONFIG_LOAD` is dispatched before the first render (`lib/index.tsx`), so a fresh window's first render already holds the final value and the paint never happens.

**Fix.** Re-add the body paint as an effect keyed on `backgroundColor`; `useEffect` runs on mount as well as on change, covering both the fresh-window case and live config edits.

**Verification.** Reproduced on 3.4.1 by driving a fresh instance over CDP with `backgroundColor: 'rgba(0,0,0,0.47)'` and no CSS workarounds:

- before: `document.body.style.backgroundColor === ''`, alpha-preserving `Page.captureScreenshot` pixels `[0,0,0,0]` — no tint at all;
- after executing exactly this paint statement in the live renderer: computed body background `rgba(0, 0, 0, 0.47)`, captured pixels `[0,0,0,120]` (120/255 ≈ 0.47).

🤖 Generated with [Claude Code](https://claude.com/claude-code)