### PR TITLE
feat: Apply downloaded update when all windows are closed

### DIFF
--- a/app/index.ts
+++ b/app/index.ts
@@ -34,6 +34,7 @@ import parseUrl from 'parse-url';
 import * as AppMenu from './menus/menu';
 import * as plugins from './plugins';
 import {newWindow} from './ui/window';
+import {installUpdateIfNoWindows} from './updater';
 import {installCLI} from './utils/cli-install';
 import * as windowUtils from './utils/window-utils';
 
@@ -168,6 +169,9 @@ app.on('ready', () =>
       });
 
       app.on('window-all-closed', () => {
+        if (installUpdateIfNoWindows()) {
+          return;
+        }
         if (process.platform !== 'darwin') {
           app.quit();
         }

--- a/app/updater.ts
+++ b/app/updater.ts
@@ -10,6 +10,7 @@ import autoUpdaterLinux from './auto-updater-linux';
 import {getDefaultProfile} from './config';
 import {version} from './package.json';
 import {getDecoratedConfig} from './plugins';
+import {shouldAutoInstallUpdate} from './utils/should-auto-install-update';
 
 const {platform} = process;
 const isLinux = platform === 'linux';
@@ -36,6 +37,15 @@ const checkForUpdates = async () => {
 let isInit = false;
 // Default to the "stable" update channel
 let canaryUpdates = false;
+let updateReady = false;
+
+export function installUpdateIfNoWindows(): boolean {
+  if (!shouldAutoInstallUpdate(updateReady, app.getWindows().size, !isLinux)) {
+    return false;
+  }
+  autoUpdater.quitAndInstall();
+  return true;
+}
 
 const buildFeedUrl = (canary: boolean, currentVersion: string) => {
   const updatePrefix = canary ? 'releases-canary' : 'releases';
@@ -60,6 +70,13 @@ async function init() {
   const feedURL = buildFeedUrl(canaryUpdates, version);
 
   autoUpdater.setFeedURL({url: feedURL});
+
+  if (!isLinux) {
+    autoUpdater.on('update-downloaded', () => {
+      updateReady = true;
+      installUpdateIfNoWindows();
+    });
+  }
 
   setTimeout(() => {
     void checkForUpdates();

--- a/app/updater.ts
+++ b/app/updater.ts
@@ -40,7 +40,7 @@ let canaryUpdates = false;
 let updateReady = false;
 
 export function installUpdateIfNoWindows(): boolean {
-  if (!shouldAutoInstallUpdate(updateReady, app.getWindows().size, !isLinux)) {
+  if (!shouldAutoInstallUpdate(updateReady, app.getWindows().size, platform)) {
     return false;
   }
   autoUpdater.quitAndInstall();

--- a/app/utils/should-auto-install-update.ts
+++ b/app/utils/should-auto-install-update.ts
@@ -1,3 +1,7 @@
-export function shouldAutoInstallUpdate(updateReady: boolean, openWindowCount: number, canInstall: boolean): boolean {
-  return updateReady && canInstall && openWindowCount === 0;
+export function shouldAutoInstallUpdate(
+  updateReady: boolean,
+  openWindowCount: number,
+  platform: NodeJS.Platform
+): boolean {
+  return updateReady && openWindowCount === 0 && platform === 'darwin';
 }

--- a/app/utils/should-auto-install-update.ts
+++ b/app/utils/should-auto-install-update.ts
@@ -1,0 +1,3 @@
+export function shouldAutoInstallUpdate(updateReady: boolean, openWindowCount: number, canInstall: boolean): boolean {
+  return updateReady && canInstall && openWindowCount === 0;
+}

--- a/test/unit/updater.test.ts
+++ b/test/unit/updater.test.ts
@@ -1,0 +1,20 @@
+import test from 'ava';
+
+import {shouldAutoInstallUpdate} from '../../app/utils/should-auto-install-update';
+
+test('installs when an update is ready and no windows are open', (t) => {
+  t.true(shouldAutoInstallUpdate(true, 0, true));
+});
+
+test('does not install while windows are still open', (t) => {
+  t.false(shouldAutoInstallUpdate(true, 1, true));
+  t.false(shouldAutoInstallUpdate(true, 3, true));
+});
+
+test('does not install when no update has been downloaded', (t) => {
+  t.false(shouldAutoInstallUpdate(false, 0, true));
+});
+
+test('does not install when the platform cannot apply updates', (t) => {
+  t.false(shouldAutoInstallUpdate(true, 0, false));
+});

--- a/test/unit/updater.test.ts
+++ b/test/unit/updater.test.ts
@@ -2,19 +2,23 @@ import test from 'ava';
 
 import {shouldAutoInstallUpdate} from '../../app/utils/should-auto-install-update';
 
-test('installs when an update is ready and no windows are open', (t) => {
-  t.true(shouldAutoInstallUpdate(true, 0, true));
+test('installs on darwin when an update is ready and no windows are open', (t) => {
+  t.true(shouldAutoInstallUpdate(true, 0, 'darwin'));
+});
+
+test('does not install on win32 when an update is ready and no windows are open', (t) => {
+  t.false(shouldAutoInstallUpdate(true, 0, 'win32'));
+});
+
+test('does not install on linux when an update is ready and no windows are open', (t) => {
+  t.false(shouldAutoInstallUpdate(true, 0, 'linux'));
 });
 
 test('does not install while windows are still open', (t) => {
-  t.false(shouldAutoInstallUpdate(true, 1, true));
-  t.false(shouldAutoInstallUpdate(true, 3, true));
+  t.false(shouldAutoInstallUpdate(true, 1, 'darwin'));
+  t.false(shouldAutoInstallUpdate(true, 3, 'darwin'));
 });
 
 test('does not install when no update has been downloaded', (t) => {
-  t.false(shouldAutoInstallUpdate(false, 0, true));
-});
-
-test('does not install when the platform cannot apply updates', (t) => {
-  t.false(shouldAutoInstallUpdate(true, 0, false));
+  t.false(shouldAutoInstallUpdate(false, 0, 'darwin'));
 });


### PR DESCRIPTION
When an update has already been downloaded and the last Hyper window is gone, call quitAndInstall on macOS. That is the only platform where zero windows still means Hyper is running in the dock.

Windows and Linux are unchanged. Closing the last window on Windows still calls app.quit(); Electron applies a downloaded update on the next launch. Linux has no in-app installer.

Fixes #1325

pnpm run test:unit passes (12 tests), including darwin/win32/linux idle-install cases. eslint is clean on the files this PR adds or changes.